### PR TITLE
fix(graph-metrics): dedupe ownership_integrity findings

### DIFF
--- a/scripts/code-health.ts
+++ b/scripts/code-health.ts
@@ -1167,13 +1167,20 @@ export function scoreLayer34(
   }
 
   // Ownership integrity: 2 per finding against skill bucket, capped at 10.
+  // The file key includes the disputed dir when available so two findings
+  // about different dirs claimed by the same skill set produce visually
+  // distinct lines in the top-10 ranker (issue #71).
   for (const o of ownership) {
     const applied = addCost('ownership_integrity', 'skill', 2);
     perBucketCost.skill = (perBucketCost.skill || 0) + applied;
+    const skillFile = o.skills[0]
+      ? `.claude/skills/${o.skills[0]}/ownership.json`
+      : '.claude/skills';
+    const fileKey = o.dir ? `${skillFile} (${o.dir})` : skillFile;
     findings.push({
       bucket: 'skill',
       metric: 'ownership_integrity',
-      file: o.skills[0] ? `.claude/skills/${o.skills[0]}/ownership.json` : '.claude/skills',
+      file: fileKey,
       line: 1,
       current_score: scoresBefore.skill?.score ?? 0,
       expected_gain_if_fixed: applied,

--- a/scripts/lib/graph-metrics.ts
+++ b/scripts/lib/graph-metrics.ts
@@ -42,7 +42,34 @@ export interface FreshnessFinding {
 export interface OwnershipFinding {
   kind: 'overlap' | 'orphan' | 'cycle' | 'missing';
   detail: string;
+  /**
+   * The dir or skill identifier the finding is about. Used as part of the
+   * dedup key by `dedupeOwnershipFindings` so two findings with the same
+   * (kind, dir, skill-set) tuple but different `detail` strings collapse
+   * into one. Optional for backwards compatibility with callers that did
+   * not previously set it.
+   */
+  dir?: string;
   skills: string[];
+}
+
+/**
+ * Collapse ownership findings that share the same (kind, dir, skill-set)
+ * triple. Skill order in `skills` is normalized so [a,b] and [b,a] dedup
+ * to the same entry. Preserves the first occurrence (insertion order is
+ * meaningful: the first finding for a duplicate carries the canonical
+ * detail string the upstream rendering uses).
+ */
+export function dedupeOwnershipFindings(
+  findings: OwnershipFinding[]
+): OwnershipFinding[] {
+  const seen = new Map<string, OwnershipFinding>();
+  for (const f of findings) {
+    const sortedSkills = [...f.skills].sort().join(',');
+    const key = `${f.kind}:${f.dir ?? ''}:${sortedSkills}`;
+    if (!seen.has(key)) seen.set(key, f);
+  }
+  return Array.from(seen.values());
 }
 
 // ---------------------------------------------------------------------------
@@ -306,11 +333,12 @@ export function skillOwnershipIntegrity(skillsDir: string): OwnershipFinding[] {
       out.push({
         kind: 'overlap',
         detail: `dir ${dir} claimed by ${owners.join(', ')}`,
+        dir,
         skills: owners,
       });
     }
   }
-  return out;
+  return dedupeOwnershipFindings(out);
 }
 
 /** Wrap a list of findings, preserving order, limited to N. */
@@ -324,4 +352,5 @@ module.exports = {
   danglingReferences,
   activityFreshness,
   skillOwnershipIntegrity,
+  dedupeOwnershipFindings,
 };

--- a/web/test/graph-metrics.test.ts
+++ b/web/test/graph-metrics.test.ts
@@ -15,6 +15,7 @@ const {
   danglingReferences,
   activityFreshness,
   skillOwnershipIntegrity,
+  dedupeOwnershipFindings,
 } = require('../../scripts/lib/graph-metrics');
 
 function mkTmp(prefix: string): string {
@@ -215,5 +216,63 @@ describe('skillOwnershipIntegrity', () => {
 
   it('returns empty for missing dir (edge)', () => {
     assert.deepEqual(skillOwnershipIntegrity('/tmp/does-not-exist-xyz-pr-d'), []);
+  });
+});
+
+describe('dedupeOwnershipFindings', () => {
+  it('collapses two findings with same kind/dir/skill-set into one regardless of skill order', () => {
+    const input = [
+      { kind: 'overlap', detail: 'dir foo claimed by a, b', dir: '.claude/skills/foo', skills: ['a', 'b'] },
+      { kind: 'overlap', detail: 'dir foo claimed by b, a', dir: '.claude/skills/foo', skills: ['b', 'a'] },
+    ];
+    const out = dedupeOwnershipFindings(input);
+    assert.equal(out.length, 1);
+  });
+
+  it('keeps findings with same dir but different skill sets', () => {
+    const input = [
+      { kind: 'overlap', detail: 'd1', dir: '.claude/skills/foo', skills: ['a', 'b'] },
+      { kind: 'overlap', detail: 'd2', dir: '.claude/skills/foo', skills: ['a', 'c'] },
+    ];
+    assert.equal(dedupeOwnershipFindings(input).length, 2);
+  });
+
+  it('keeps findings with same skill set but different dirs', () => {
+    const input = [
+      { kind: 'orphan', detail: 'd1', dir: '.claude/skills/foo', skills: ['a'] },
+      { kind: 'orphan', detail: 'd2', dir: '.claude/skills/bar', skills: ['a'] },
+    ];
+    assert.equal(dedupeOwnershipFindings(input).length, 2);
+  });
+
+  it('keeps findings with same dir + skills but different kinds', () => {
+    const input = [
+      { kind: 'overlap', detail: 'd1', dir: '.claude/skills/foo', skills: ['a'] },
+      { kind: 'orphan', detail: 'd2', dir: '.claude/skills/foo', skills: ['a'] },
+    ];
+    assert.equal(dedupeOwnershipFindings(input).length, 2);
+  });
+
+  it('preserves the first finding when collapsing duplicates', () => {
+    const first = { kind: 'overlap', detail: 'first', dir: '.claude/skills/foo', skills: ['a', 'b'] };
+    const second = { kind: 'overlap', detail: 'second', dir: '.claude/skills/foo', skills: ['b', 'a'] };
+    const out = dedupeOwnershipFindings([first, second]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].detail, 'first');
+  });
+});
+
+describe('skillOwnershipIntegrity dedup integration', () => {
+  it('returned findings are already deduped at the source', () => {
+    // The function should never return two findings with the same
+    // (kind, dir, skill-set) tuple even if the detail string differs.
+    const root = mkTmp('soi-dedup');
+    try {
+      writeFile(root, 'a/ownership.json', JSON.stringify({ files: [], dirs: ['shared/'] }));
+      writeFile(root, 'b/ownership.json', JSON.stringify({ files: [], dirs: ['shared/'] }));
+      const findings = skillOwnershipIntegrity(root);
+      const sharedFindings = findings.filter((f: any) => f.dir === 'shared');
+      assert.equal(sharedFindings.length, 1);
+    } finally { rmTmp(root); }
   });
 });


### PR DESCRIPTION
## Summary

- Adds dedupeOwnershipFindings helper to scripts/lib/graph-metrics.ts (kind:dir:sorted-skills key, normalizes skill order, preserves first occurrence)
- Extends OwnershipFinding interface with optional dir field, populated when pushing overlap findings
- skillOwnershipIntegrity wraps its return in dedupeOwnershipFindings so callers receive canonical data
- code-health.ts file key includes the disputed dir so two findings about different dirs claimed by the same skill set render visually distinct in the top-10 ranker (the user-visible symptom that motivated #71)
- Fixes a hidden gotcha: graph-metrics.ts has both \`export function\` syntax AND a manual \`module.exports = {...}\` block at line 350 for CJS interop. New functions must appear in both. The plan missed this; the implementation discovered and worked around it.

## Plan

Source plan: \`.claude/plans/fluffy-hugging-wilkes.md\` (Commit 4 of 9)

## Test plan

- [x] TDD red phase: 6 new tests fail before implementation
- [x] TDD green phase: all 20 graph-metrics tests pass after implementation
- [x] \`npm test\` passes 835/835 (829 baseline + 6 new)
- [x] \`npm run health\` top-10 output now shows distinct lines per disputed dir, e.g. \`.claude/skills/play/ownership.json (learning/sessions):1\` vs \`.claude/skills/play/ownership.json (learning/vault):1\`
- [x] Verifier subagent flagged the visual-rendering gap; folded the file-key fix into this commit

Closes #71