### PR TITLE
feat(notes): scripts/note.ts CLI + notes.jsonl semantic stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Run `npm run health` before and after refactors. See `references/config/code-hea
 
 All events (tool calls, session lifecycle, warnings, errors) go to one file: `learning/logs/raw.jsonl`. Both the shared hooks (terminal /play) and the web server logger write here. The `/fix` skill reads this file to diagnose issues. (PR-B unified the previous `activity.jsonl` + `system.jsonl` split into a single stream; the legacy filenames now alias to `raw.jsonl` via `web/lib/paths.ts`.)
 
+Agents record findings, negative results, workarounds, and decisions to a parallel stream `learning/logs/notes.jsonl` via the `scripts/note.ts` CLI. Schema: `{ts, kind, topic, body}`. Kinds: `finding`, `negative_result`, `workaround`, `decision`, `none`. The `none` kind is the explicit "nothing worth recording" escape hatch and requires `--reason`. A Stop hook enforces that every session records at least one note before exiting.
+
 ## System vault
 
 Long-term system memory lives in `learning/system-vault/` (per-user, gitignored). Query it via `system-vault-query` when you need prior findings, decisions, or workarounds; the daily-compile-and-rotate cron compiles `raw.jsonl` into topic notes and the dream-check hook periodically consolidates them. Budgets are enforced by `web/lib/system-vault.ts`.

--- a/references/registries/path-registry.csv
+++ b/references/registries/path-registry.csv
@@ -260,9 +260,11 @@ CLAUDE.md,references/registries/tool-registry.md,21
 CLAUDE.md,references/config/code-health.md,25
 CLAUDE.md,learning/logs/raw.jsonl,29
 CLAUDE.md,web/lib/paths.ts,29
-CLAUDE.md,learning/system-vault/,33
-CLAUDE.md,web/lib/system-vault.ts,33
-CLAUDE.md,references/architecture/core-workflow.md,37
+CLAUDE.md,learning/logs/notes.jsonl,31
+CLAUDE.md,scripts/note.ts,31
+CLAUDE.md,learning/system-vault/,35
+CLAUDE.md,web/lib/system-vault.ts,35
+CLAUDE.md,references/architecture/core-workflow.md,39
 references/architecture/core-workflow.md,.claude/,17
 references/architecture/core-workflow.md,references/architecture/testing-system.md,78
 references/architecture/game-design-document.md,references/config/progression.yaml,3

--- a/scripts/note.ts
+++ b/scripts/note.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/note.ts
+ *
+ * Small CLI agents call to record findings, negative results, workarounds,
+ * and decisions to learning/logs/notes.jsonl. The Stop hook (Commit 8 of
+ * the fluffy-hugging-wilkes plan) blocks session end until at least one
+ * note has been recorded for the current session. The kind=none escape
+ * hatch is the explicit "nothing worth recording" path.
+ *
+ * Schema: {ts, kind, topic, body}.
+ * Kinds: finding, negative_result, workaround, decision, none.
+ * Topic: slug ^[a-z0-9][a-z0-9-]{0,63}$ (or "none" for kind=none).
+ * Body: freeform text, max 500 chars.
+ *
+ * Usage:
+ *   tsx scripts/note.ts --kind finding --topic <slug> --body "<one to three sentences>"
+ *   tsx scripts/note.ts --kind negative_result --topic <slug> --body "tried X, did not work because Y"
+ *   tsx scripts/note.ts --kind workaround --topic <slug> --body "<what you did>"
+ *   tsx scripts/note.ts --kind decision --topic <slug> --body "<what was decided and why>"
+ *   tsx scripts/note.ts --kind none --reason "<one-line reason>"
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const KINDS = new Set(['finding', 'negative_result', 'workaround', 'decision', 'none']);
+const TOPIC_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const MAX_BODY = 500;
+
+interface ParsedArgs {
+  kind?: string;
+  topic?: string;
+  body?: string;
+  reason?: string;
+}
+
+interface NoteEntry {
+  ts: string;
+  kind: string;
+  topic: string;
+  body: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (!flag || !flag.startsWith('--')) continue;
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`flag ${flag} requires a value`);
+    }
+    const key = flag.slice(2);
+    (out as Record<string, string>)[key] = value;
+    i++;
+  }
+  return out;
+}
+
+function validate(args: ParsedArgs): NoteEntry {
+  if (!args.kind || !KINDS.has(args.kind)) {
+    throw new Error(`--kind must be one of: ${[...KINDS].join(', ')}`);
+  }
+  const ts = new Date().toISOString();
+  if (args.kind === 'none') {
+    if (!args.reason) {
+      throw new Error('--kind none requires --reason "<one-line reason>"');
+    }
+    return {
+      ts,
+      kind: 'none',
+      topic: 'none',
+      body: `none: ${args.reason}`,
+    };
+  }
+  if (!args.topic || !TOPIC_RE.test(args.topic)) {
+    throw new Error('--topic must be a slug matching ^[a-z0-9][a-z0-9-]{0,63}$');
+  }
+  if (!args.body) {
+    throw new Error('--body is required');
+  }
+  if (args.body.length > MAX_BODY) {
+    throw new Error(`--body must be at most ${MAX_BODY} characters (got ${args.body.length})`);
+  }
+  return {
+    ts,
+    kind: args.kind,
+    topic: args.topic,
+    body: args.body,
+  };
+}
+
+function appendEntry(entry: NoteEntry, notesPath: string): void {
+  mkdirSync(path.dirname(notesPath), { recursive: true });
+  appendFileSync(notesPath, JSON.stringify(entry) + '\n');
+}
+
+function main(): void {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const entry = validate(args);
+    const notesPath = path.resolve(process.cwd(), 'learning', 'logs', 'notes.jsonl');
+    appendEntry(entry, notesPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`note: ${message}\n`);
+    process.exit(2);
+  }
+}
+
+main();
+
+export { parseArgs, validate, appendEntry, KINDS, TOPIC_RE, MAX_BODY };

--- a/web/lib/paths.ts
+++ b/web/lib/paths.ts
@@ -22,6 +22,11 @@ const JOURNAL: string = path.join(LEARNING_DIR, 'journal.md');
 const RAW_LOG_FILE: string = path.join(LOGS_DIR, 'raw.jsonl');
 const LOG_FILE: string = RAW_LOG_FILE;
 const SYSTEM_LOG_FILE: string = RAW_LOG_FILE;
+// Notes log: agent-authored semantic stream parallel to raw.jsonl. The
+// scripts/note.ts CLI appends here. Compile reads it as the primary topic
+// source. The Stop hook (.claude/hooks/stop-journal-check.ts) checks this
+// file to enforce per-session note recording.
+const NOTES_LOG_FILE: string = path.join(LOGS_DIR, 'notes.jsonl');
 const HEALTH_SCORES_FILE: string = path.join(LOGS_DIR, 'health-scores.jsonl');
 const CATALOG: string = path.join(LEARNING_DIR, 'catalog.csv');
 const THEME_BASE: string = path.join(THEMES_DIR, '_base.md');
@@ -52,6 +57,7 @@ const paths = {
   LOG_FILE,
   SYSTEM_LOG_FILE,
   RAW_LOG_FILE,
+  NOTES_LOG_FILE,
   HEALTH_SCORES_FILE,
   CATALOG,
   THEME_BASE,

--- a/web/test/note-cli.test.ts
+++ b/web/test/note-cli.test.ts
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * note-cli.test.ts
+ *
+ * Tests scripts/note.ts: a small CLI that appends one validated JSONL line per
+ * call to learning/logs/notes.jsonl. Schema {ts, kind, topic, body}. Five
+ * kinds (finding, negative_result, workaround, decision, none). The "none"
+ * kind is the explicit escape hatch and requires a --reason flag.
+ *
+ * Each test runs the CLI as a subprocess in a tmp working directory so the
+ * real learning/logs/ does not get polluted.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const NOTE_SCRIPT = path.join(REPO_ROOT, 'scripts', 'note.ts');
+
+function runNote(cwd: string, args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync('npx', ['tsx', NOTE_SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function readNotes(cwd: string): any[] {
+  const p = path.join(cwd, 'learning', 'logs', 'notes.jsonl');
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf8')
+    .split('\n')
+    .filter((line: string) => line.trim().length > 0)
+    .map((line: string) => JSON.parse(line));
+}
+
+function makeTmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'note-cli-'));
+  fs.mkdirSync(path.join(dir, 'learning', 'logs'), { recursive: true });
+  return dir;
+}
+
+function rmTmp(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+describe('note CLI', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeTmp(); });
+  afterEach(() => { rmTmp(tmp); });
+
+  it('appends a valid finding entry to notes.jsonl', () => {
+    const r = runNote(tmp, ['--kind', 'finding', '--topic', 'test-symptom', '--body', 'observed X happening repeatedly']);
+    assert.equal(r.status, 0, `expected success, stderr: ${r.stderr}`);
+    const entries = readNotes(tmp);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].kind, 'finding');
+    assert.equal(entries[0].topic, 'test-symptom');
+    assert.equal(entries[0].body, 'observed X happening repeatedly');
+    assert.ok(typeof entries[0].ts === 'string' && entries[0].ts.length > 0);
+  });
+
+  it('appends a negative_result entry', () => {
+    const r = runNote(tmp, ['--kind', 'negative_result', '--topic', 'tried-x', '--body', 'X did not work because Y']);
+    assert.equal(r.status, 0);
+    const entries = readNotes(tmp);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].kind, 'negative_result');
+  });
+
+  it('appends a workaround entry', () => {
+    const r = runNote(tmp, ['--kind', 'workaround', '--topic', 'fix-build', '--body', 'manually deleted the lockfile']);
+    assert.equal(r.status, 0);
+    const entries = readNotes(tmp);
+    assert.equal(entries[0].kind, 'workaround');
+  });
+
+  it('appends a decision entry', () => {
+    const r = runNote(tmp, ['--kind', 'decision', '--topic', 'use-postgres', '--body', 'switched from sqlite to postgres for concurrent writes']);
+    assert.equal(r.status, 0);
+    const entries = readNotes(tmp);
+    assert.equal(entries[0].kind, 'decision');
+  });
+
+  it('rejects an unknown kind with non-zero exit and stderr', () => {
+    const r = runNote(tmp, ['--kind', 'nonsense', '--topic', 'foo', '--body', 'bar']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /kind/i);
+  });
+
+  it('rejects topic with invalid characters', () => {
+    const r = runNote(tmp, ['--kind', 'finding', '--topic', 'Has Spaces', '--body', 'x']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /topic/i);
+  });
+
+  it('rejects body longer than 500 characters', () => {
+    const longBody = 'x'.repeat(501);
+    const r = runNote(tmp, ['--kind', 'finding', '--topic', 'foo', '--body', longBody]);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /500|body/i);
+  });
+
+  it('accepts kind=none with --reason', () => {
+    const r = runNote(tmp, ['--kind', 'none', '--reason', 'ran tests, all green']);
+    assert.equal(r.status, 0, `expected success, stderr: ${r.stderr}`);
+    const entries = readNotes(tmp);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].kind, 'none');
+    assert.equal(entries[0].topic, 'none');
+    assert.match(entries[0].body, /ran tests, all green/);
+  });
+
+  it('rejects kind=none without --reason', () => {
+    const r = runNote(tmp, ['--kind', 'none']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /reason/i);
+  });
+
+  it('appends multiple entries to the same file across runs', () => {
+    runNote(tmp, ['--kind', 'finding', '--topic', 'first', '--body', 'first body']);
+    runNote(tmp, ['--kind', 'finding', '--topic', 'second', '--body', 'second body']);
+    const entries = readNotes(tmp);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].topic, 'first');
+    assert.equal(entries[1].topic, 'second');
+  });
+
+  it('creates learning/logs/ if it does not exist', () => {
+    fs.rmSync(path.join(tmp, 'learning', 'logs'), { recursive: true, force: true });
+    const r = runNote(tmp, ['--kind', 'finding', '--topic', 'auto-mkdir', '--body', 'created']);
+    assert.equal(r.status, 0, `expected success, stderr: ${r.stderr}`);
+    assert.ok(fs.existsSync(path.join(tmp, 'learning', 'logs', 'notes.jsonl')));
+  });
+});

--- a/web/test/paths.test.ts
+++ b/web/test/paths.test.ts
@@ -20,6 +20,10 @@ describe('paths', () => {
     it('PROFILE points to learning/profile.json', () => {
       assert.ok(paths.PROFILE.endsWith(path.join('learning', 'profile.json')));
     });
+
+    it('NOTES_LOG_FILE points to learning/logs/notes.jsonl', () => {
+      assert.ok(paths.NOTES_LOG_FILE.endsWith(path.join('learning', 'logs', 'notes.jsonl')));
+    });
   });
 
   describe('dynamic helpers', () => {


### PR DESCRIPTION
## Summary

- New \`scripts/note.ts\` CLI agents call to record findings, negative results, workarounds, and decisions to \`learning/logs/notes.jsonl\`
- Schema \`{ts, kind, topic, body}\`. Five kinds: finding, negative_result, workaround, decision, none. The \`none\` kind is the explicit "nothing worth recording" escape hatch and requires \`--reason\`
- Topic is a slug \`^[a-z0-9][a-z0-9-]{0,63}$\`, body capped at 500 chars
- Parallel stream to raw.jsonl (not unified) because notes are low-frequency semantic content while raw.jsonl is high-frequency mechanical noise
- New \`NOTES_LOG_FILE\` constant in \`web/lib/paths.ts\`
- Closes the semantic gap in the learning loop: previously the compile skill had nothing topic-rich to bucket; now notes.jsonl is the primary semantic source (Commit 9 wires up the compile integration)

## Plan

Source plan: \`.claude/plans/fluffy-hugging-wilkes.md\` (Commit 7 of 9)

## Test plan

- [x] TDD red phase: 11 failing tests before implementation
- [x] TDD green phase: 11/11 tests pass after implementation
- [x] \`npm test\` passes 847/847 (835 baseline + 11 note-cli + 1 paths)
- [x] Verifier subagent confirmed all 9 checks PASS
- [x] CLAUDE.md updated to mention the notes.jsonl stream (Stop hook mentioned generically; Commit 8 adds the actual hook file)

Ref #81