### PR TITLE
feat(system-vault): compile reads notes.jsonl as primary semantic source

### DIFF
--- a/.claude/scheduled-jobs/daily-compile-and-rotate.json
+++ b/.claude/scheduled-jobs/daily-compile-and-rotate.json
@@ -22,10 +22,12 @@
   "allowed_write_paths": [
     "learning/system-vault/**",
     "learning/logs/compile-pending.txt",
+    "learning/logs/notes.jsonl",
+    "learning/logs/notes.jsonl.*.gz",
     "learning/logs/raw.jsonl",
     "learning/logs/raw.jsonl.*.gz",
     "learning/logs/archive/**",
     ".claude/state/vault-circuit.json"
   ],
-  "prompt": "If learning/logs/compile-pending.txt exists and is non-empty, read it and collect the unique SHAs as scope hints. Run the system-vault-compile skill to compile today's raw.jsonl into the system vault, passing the collected SHAs as explicit scope context (compile topics touching these commits plus the last 24h of raw.jsonl). After the skill returns successfully, truncate compile-pending.txt to empty (do not delete the file, the post-commit hook appends to it). Then rotate raw.jsonl by gzipping yesterday's segment into learning/logs/archive/. On success, reset compile_failures in .claude/state/vault-circuit.json. On any failure (skill or rotation), increment compile_failures, do not truncate compile-pending.txt, and do not proceed to subsequent steps."
+  "prompt": "If learning/logs/compile-pending.txt exists and is non-empty, read it and collect the unique SHAs as scope hints. Run the system-vault-compile skill to compile today's notes.jsonl (primary semantic source) and raw.jsonl (session metadata) into the system vault, passing the collected SHAs as explicit scope context (compile topics touching these commits plus the last 24h of notes.jsonl and raw.jsonl). After the skill returns successfully, truncate compile-pending.txt to empty (do not delete the file, the post-commit hook appends to it). Then rotate BOTH notes.jsonl and raw.jsonl by gzipping yesterday's segments into learning/logs/archive/. On success, reset compile_failures in .claude/state/vault-circuit.json. On any failure (skill or rotation), increment compile_failures, do not truncate compile-pending.txt, and do not proceed to subsequent steps."
 }

--- a/.claude/skills/system-vault-compile/SKILL.md
+++ b/.claude/skills/system-vault-compile/SKILL.md
@@ -9,15 +9,17 @@ effort: low
 references_system_vault: true
 paths:
   - learning/system-vault/**
+  - learning/logs/notes.jsonl
   - learning/logs/raw.jsonl
   - .claude/state/vault-circuit.json
 ---
 
 # system-vault-compile Skill
 
-Compile the last 24 hours of `learning/logs/raw.jsonl` into structured
-topic notes under `learning/system-vault/`. Update `index.md`. Respect
-the size budgets defined in `web/lib/system-vault.ts`:
+Compile the last 24 hours of `learning/logs/notes.jsonl` (primary
+semantic source) and `learning/logs/raw.jsonl` (session metadata) into
+structured topic notes under `learning/system-vault/`. Update
+`index.md`. Respect the size budgets defined in `web/lib/system-vault.ts`:
 
 - `index.md` must be at most 200 lines.
 - Every topic markdown file must be at most 4KB.
@@ -31,19 +33,21 @@ topic worth compiling, read the diff via `git show <sha>` if needed
 to identify affected topics. The caller is responsible for truncating
 `compile-pending.txt` after this skill returns successfully; this skill
 never writes to that file. Manual invocations (no SHA list) fall back
-to the default 24h scan over `learning/logs/raw.jsonl` unchanged.
+to the default 24h scan over `learning/logs/notes.jsonl` and
+`learning/logs/raw.jsonl` unchanged.
 
 ## Tool Reference
 
 | Step | Action | Tool | Target |
 |------|--------|------|--------|
 | 1 | Read circuit state | Read | `.claude/state/vault-circuit.json` |
-| 2 | Read raw log | Read | `learning/logs/raw.jsonl` |
-| 3 | Load compile prompt | Read | `.claude/skills/system-vault-compile/references/compile-prompt.md` |
-| 4 | Load rotation policy | Read | `.claude/skills/system-vault-compile/references/rotation-policy.md` |
-| 5 | Write topic files | Write | `learning/system-vault/<subdir>/<slug>.md` |
-| 6 | Update index | Edit | `learning/system-vault/index.md` |
-| 7 | Update circuit | Edit | `.claude/state/vault-circuit.json` |
+| 2 | Read notes log | Read | `learning/logs/notes.jsonl` |
+| 3 | Read raw log | Read | `learning/logs/raw.jsonl` |
+| 4 | Load compile prompt | Read | `.claude/skills/system-vault-compile/references/compile-prompt.md` |
+| 5 | Load rotation policy | Read | `.claude/skills/system-vault-compile/references/rotation-policy.md` |
+| 6 | Write topic files | Write | `learning/system-vault/<subdir>/<slug>.md` |
+| 7 | Update index | Edit | `learning/system-vault/index.md` |
+| 8 | Update circuit | Edit | `.claude/state/vault-circuit.json` |
 
 ---
 
@@ -55,12 +59,22 @@ Read `.claude/state/vault-circuit.json`. If `paused` is true, exit
 without writing. If `compile_failures` is at least 3, exit without
 writing. The cron operator should investigate.
 
-### 2. Read the raw log window
+### 2. Read the notes log window
 
-Read `learning/logs/raw.jsonl`. Filter to entries from the last 24 hours.
-If the file is empty, exit cleanly with no changes.
+Read `learning/logs/notes.jsonl`. Filter to entries from the last 24
+hours. Each entry is a JSON object with `{ts, kind, topic, body}`.
+This is the primary semantic source, every entry is a topic claim
+the agent made about its session.
 
-### 3. Compile
+### 3. Read the raw log window
+
+Read `learning/logs/raw.jsonl`. Filter to entries from the last 24
+hours. The raw log carries only session metadata (SessionStart,
+PostToolUse, Stop, Failure events). It is supplementary context, not
+the primary signal. If both files are empty, exit cleanly with no
+changes.
+
+### 4. Compile
 
 Follow the prompt in
 `.claude/skills/system-vault-compile/references/compile-prompt.md`.
@@ -69,24 +83,25 @@ subdirectory: `findings/`, `workarounds/`, `decisions/`, `sessions/`,
 `components/`, `health/`. Each topic file stays under 4KB. If a topic
 note would exceed 4KB, split it by date suffix.
 
-### 4. Update the index
+### 5. Update the index
 
 Rebuild `learning/system-vault/index.md` from the topic file tree. Keep
 it under 200 lines. Use sections per subdirectory with wiki-links to
 each topic file.
 
-### 5. Update the circuit
+### 6. Update the circuit
 
 On success, set `compile_failures` to 0 in
 `.claude/state/vault-circuit.json` and write the current ISO timestamp
 under `last_compile_ts`. On any failure, increment `compile_failures`
 and exit non-zero so the cron does not proceed to rotation.
 
-### 6. Rotation
+### 7. Rotation
 
 After a successful compile, follow
 `.claude/skills/system-vault-compile/references/rotation-policy.md` to
-gzip yesterday's segment of `raw.jsonl` into `learning/logs/archive/`.
+gzip yesterday's segments of `notes.jsonl` and `raw.jsonl` into
+`learning/logs/archive/`.
 
 ---
 
@@ -95,6 +110,6 @@ gzip yesterday's segment of `raw.jsonl` into `learning/logs/archive/`.
 1. No emojis.
 2. Never delete topic files. Use `system-vault-prune` for that.
 3. Never write outside `learning/system-vault/**`,
-   `learning/logs/raw.jsonl`, `learning/logs/archive/**`, or
-   `.claude/state/vault-circuit.json`.
+   `learning/logs/notes.jsonl`, `learning/logs/raw.jsonl`,
+   `learning/logs/archive/**`, or `.claude/state/vault-circuit.json`.
 4. Atomic: if any phase fails, increment the failure counter and exit.

--- a/.claude/skills/system-vault-compile/references/compile-prompt.md
+++ b/.claude/skills/system-vault-compile/references/compile-prompt.md
@@ -1,27 +1,39 @@
 # Compile prompt
 
-You are compiling 24 hours of `learning/logs/raw.jsonl` into the system
-vault. The vault is the system's long-term memory: stable, structured,
-small.
+You are compiling 24 hours of `learning/logs/notes.jsonl` (primary
+semantic source) and `learning/logs/raw.jsonl` (supplementary session
+metadata) into the system vault. The vault is the system's long-term
+memory: stable, structured, small.
 
 ## Inputs
 
-- `learning/logs/raw.jsonl` (last 24 hours, JSONL).
+- `learning/logs/notes.jsonl` (last 24 hours, JSONL). Each entry is
+  `{ts, kind, topic, body}` written by `scripts/note.ts`. This is the
+  primary semantic signal: every entry is a topic claim the agent made.
+- `learning/logs/raw.jsonl` (last 24 hours, JSONL). Mechanical session
+  metadata (SessionStart, PostToolUse, Stop, Failure events).
 - Existing files under `learning/system-vault/`.
 
 ## Output layout
 
-Each entry in the raw log belongs to exactly one topic. Choose the
-subdirectory by event type:
+The notes log carries the primary semantic signal. Map by `kind`:
 
-| Source event | Subdirectory | Notes |
-|--------------|--------------|-------|
-| `error`, `warning`, persistent failure | `findings/` | One file per recurring symptom |
-| Manual workaround applied during a session | `workarounds/` | Title summarizes the symptom |
-| Architectural choice or convention | `decisions/` | One file per decision, ADR style |
-| Sim play session lifecycle | `sessions/` | One file per session id |
+| `kind` | Subdirectory | Notes |
+|--------|--------------|-------|
+| `finding` | `findings/` | One file per recurring symptom; merge if existing |
+| `negative_result` | `findings/` | File name suffix `-negative.md`; preserves "tried X, did not work" trail |
+| `workaround` | `workarounds/` | One file per symptom and applied fix |
+| `decision` | `decisions/` | One file per decision, ADR style |
+| `none` | dropped | Escape hatch from the Stop hook; carries no signal |
+
+The raw log is supplementary. Use it for:
+
+| Source event in raw.jsonl | Subdirectory | Notes |
+|---------------------------|--------------|-------|
+| `Failure` (with `kind: tool` or `kind: stop`) | `findings/` | One file per recurring symptom |
+| `SessionStart` and `Stop` pair | `sessions/` | One file per `session_id`, summarizing session shape (tool counts, duration) |
+| Code health snapshot | `health/` | Single rolling file `current.md` |
 | Code health regression on a module | `components/` | One file per affected module |
-| Health snapshot | health subdir | Single rolling file `current.md` |
 
 ## File rules
 
@@ -42,6 +54,7 @@ bullet with a one-line summary. The index must be at most 200 lines.
 
 ## Failure mode
 
-If you cannot determine a topic for an entry, drop it (the raw log is
-the source of truth). Do not invent content. Do not summarize sessions
-that are still in progress.
+If you cannot determine a topic for a notes entry, use `topic` from
+the entry directly (it is already a slug). For raw log entries with
+no obvious topic, drop them. Do not invent content. Do not summarize
+sessions that are still in progress.

--- a/.claude/skills/system-vault-compile/references/rotation-policy.md
+++ b/.claude/skills/system-vault-compile/references/rotation-policy.md
@@ -1,11 +1,12 @@
 # Rotation policy
 
-The daily-compile-and-rotate cron rotates `learning/logs/raw.jsonl`
-after a successful compile.
+The daily-compile-and-rotate cron rotates BOTH `learning/logs/raw.jsonl`
+and `learning/logs/notes.jsonl` after a successful compile.
 
 ## Window
 
-- Archives are gzipped to `learning/logs/archive/raw.jsonl.<YYYY-MM-DD>.gz`.
+- Archives are gzipped to `learning/logs/archive/raw.jsonl.<YYYY-MM-DD>.gz`
+  and `learning/logs/archive/notes.jsonl.<YYYY-MM-DD>.gz` respectively.
 - Archives older than 7 days may be considered for deletion.
 - Archives older than 90 days are out of window: deletion is refused.
 - Archives still referenced by any vault topic file (via `source_archives`
@@ -16,13 +17,15 @@ encodes these rules. The cron should consult it before any unlink.
 
 ## Procedure
 
-1. After compile succeeds, identify the segment of `raw.jsonl` whose
-   timestamps fall on the previous calendar day, in local time.
-2. Move that segment to `learning/logs/archive/raw.jsonl.<YYYY-MM-DD>`.
-3. Gzip the archive in place: produces `raw.jsonl.<YYYY-MM-DD>.gz`.
-4. For every existing `*.gz` archive, call the predicate. If the
-   predicate returns `allow: false`, leave the archive in place. If it
-   returns `allow: true`, unlink the archive.
+For each of `raw.jsonl` and `notes.jsonl`:
+
+1. After compile succeeds, identify the segment whose timestamps fall
+   on the previous calendar day, in local time.
+2. Move that segment to `learning/logs/archive/<filename>.<YYYY-MM-DD>`.
+3. Gzip the archive in place.
+4. For every existing `*.gz` archive, call the `canRotate` predicate.
+   If it returns `allow: false`, leave the archive in place. If
+   `allow: true`, unlink it.
 
 ## Failure mode
 

--- a/references/architecture/workspace-map.md
+++ b/references/architecture/workspace-map.md
@@ -145,7 +145,7 @@ Tracked manifests under `.claude/scheduled-jobs/` define RemoteTrigger crons wit
 
 | Automation | Type | Trigger | Purpose | Source file |
 |---|---|---|---|---|
-| daily-compile-and-rotate | cron | 03:00 local daily | Compile `learning/logs/raw.jsonl` into `learning/system-vault/` topic notes, rotate old log shards, append health score | `.claude/scheduled-jobs/daily-compile-and-rotate.json` |
+| daily-compile-and-rotate | cron | 03:00 local daily | Compile `learning/logs/notes.jsonl` (primary semantic source) and `learning/logs/raw.jsonl` (session metadata) into `learning/system-vault/` topic notes, rotate both log files, append health score | `.claude/scheduled-jobs/daily-compile-and-rotate.json` |
 | weekly-fight-team | cron | Sunday 04:00 local | Run 4-round fight-team debate over top 10 findings in `learning/logs/health-scores.jsonl`, file copy-paste-ready GitHub Issues via `scripts/lib/validate-fight-team-issue.ts` | `.claude/scheduled-jobs/weekly-fight-team.json` |
 | weekly-dream | cron | Sunday 03:30 local | Run system-vault-dream skill to consolidate `learning/system-vault/`. Empty-vault guard: skip if vault has fewer than 5 topic files. | `.claude/scheduled-jobs/weekly-dream.json` |
 | system-vault-compile chain | hook (PostCommit) | after every commit | Re-run `system-vault-compile` and append to `learning/logs/health-scores.jsonl` | `.claude/settings.json` |

--- a/web/test/scheduled-jobs-boundary.test.ts
+++ b/web/test/scheduled-jobs-boundary.test.ts
@@ -13,6 +13,8 @@ const BOUNDARY: Record<string, string[]> = {
   'daily-compile-and-rotate': [
     'learning/system-vault/**',
     'learning/logs/compile-pending.txt',
+    'learning/logs/notes.jsonl',
+    'learning/logs/notes.jsonl.*.gz',
     'learning/logs/raw.jsonl',
     'learning/logs/raw.jsonl.*.gz',
     'learning/logs/archive/**',


### PR DESCRIPTION
## Summary

- Daily compile cron now reads notes.jsonl (the agent-authored semantic stream from Commit 7) as the primary signal source and raw.jsonl as supplementary session metadata
- Compile-prompt source-to-subdir mapping rewritten in terms of \`notes.kind\` (finding, negative_result, workaround, decision, none); the \`none\` kind is dropped (escape hatch from the Stop hook)
- Rotation policy extended to gzip BOTH files daily
- Closes the loop with Commit 5's weekly-dream cron and Commit 8's Stop hook: the system vault finally has actual content to consolidate

After this commit, the full Sunday morning sequence is wired:
- 03:00 daily-compile reads notes.jsonl + raw.jsonl, populates \`learning/system-vault/\`, rotates both files
- 03:30 weekly-dream consolidates the now-populated vault (skipped if vault still has fewer than 5 topic files)
- 04:00 weekly-fight-team debates the top findings

## Plan

Source plan: \`.claude/plans/fluffy-hugging-wilkes.md\` (Commit 9 of 9, FINAL)

## Test plan

- [x] \`npm test\` passes 855/855
- [x] scheduled-jobs-boundary.test.ts: 6/6 PASS with extended BOUNDARY fixture
- [x] JSON in daily-compile-and-rotate.json validates
- [x] Failure-mode semantics from Commit 2 preserved (no truncate on failure, no rotation after compile failure)
- [x] Verifier subagent flagged 3 internal-consistency stale-text issues in SKILL.md (intro paragraph, Pending markers section, Rules section); folded all three fixes into this commit

Ref #81