### PR TITLE
Pipeline: replace sleep 10 label wait with retry loop

### DIFF
--- a/.github/workflows/critic.yml
+++ b/.github/workflows/critic.yml
@@ -38,7 +38,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          sleep 10
+          for attempt in 1 2 3 4 5; do
+            labels_check=$(gh issue view "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '[.labels[].name] | join(",")')
+            if echo "$labels_check" | grep -qE "text-only|ui|sim-content"; then
+              break
+            fi
+            sleep 3
+          done
 
           N=${{ github.event.issue.number }}
           labels=$(gh issue view "$N" --repo ${{ github.repository }} \

--- a/.github/workflows/implementer.yml
+++ b/.github/workflows/implementer.yml
@@ -51,7 +51,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          sleep 10
+          for attempt in 1 2 3 4 5; do
+            labels_check=$(gh issue view "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '[.labels[].name] | join(",")')
+            if echo "$labels_check" | grep -qE "text-only|ui|sim-content"; then
+              break
+            fi
+            sleep 3
+          done
 
           N=${{ github.event.issue.number }}
           labels=$(gh issue view "$N" --repo ${{ github.repository }} \

--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -38,9 +38,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          # Give the issue creator time to attach a type label
-          # (text-only, ui, sim-content) after adding the trigger label.
-          sleep 10
+          # Retry until a type label (text-only, ui, sim-content) appears.
+          for attempt in 1 2 3 4 5; do
+            labels_check=$(gh issue view "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '[.labels[].name] | join(",")')
+            if echo "$labels_check" | grep -qE "text-only|ui|sim-content"; then
+              break
+            fi
+            sleep 3
+          done
 
           N=${{ github.event.issue.number }}
           labels=$(gh issue view "$N" --repo ${{ github.repository }} \

--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -52,7 +52,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          sleep 10
+          for attempt in 1 2 3 4 5; do
+            labels_check=$(gh issue view "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --json labels --jq '[.labels[].name] | join(",")')
+            if echo "$labels_check" | grep -qE "text-only|ui|sim-content"; then
+              break
+            fi
+            sleep 3
+          done
 
           N=${{ github.event.issue.number }}
           labels=$(gh issue view "$N" --repo ${{ github.repository }} \


### PR DESCRIPTION
Closes #180

Replaces `sleep 10` in all four pipeline workflows with a 5-attempt retry loop (3s between attempts) that checks for type labels before proceeding. Falls back to unlabeled behavior if no type label found after all attempts.