### PR TITLE
ci: add session continuity, actions:read, and failure handlers

### DIFF
--- a/.github/workflows/critic.yml
+++ b/.github/workflows/critic.yml
@@ -80,16 +80,42 @@ jobs:
           echo "tools=$TOOLS" >> "$GITHUB_OUTPUT"
           echo "mcp_arg=$MCP_ARG" >> "$GITHUB_OUTPUT"
 
+      - name: Extract prior session
+        id: session
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          SESSION=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '[.comments[].body | select(startswith("<!-- session:planner:"))] | last | ltrimstr("<!-- session:planner:") | rtrimstr(" -->")' \
+            2>/dev/null || echo "")
+          if [ -n "$SESSION" ]; then
+            echo "resume_arg=--resume $SESSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "resume_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --model claude-sonnet-4-6
+            ${{ steps.session.outputs.resume_arg }}
             --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["APPROVED","REVISE"]},"summary":{"type":"string"}},"required":["verdict","summary"]}'
             ${{ steps.setup.outputs.mcp_arg }}
             --allowed-tools "${{ steps.setup.outputs.tools }}"
           prompt: ${{ steps.setup.outputs.prompt }}
+
+      - name: Store session metadata
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "<!-- session:critic:${{ steps.claude.outputs.session_id }} -->"
 
       - name: Swap labels based on critique
         env:
@@ -109,3 +135,16 @@ jobs:
               --add-label "needs-plan" \
               --add-label "revision-1"
           fi
+
+      - name: Handle stage failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "needs-critique" \
+            --add-label "pipeline-failed"
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "critic stage failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/implementer.yml
+++ b/.github/workflows/implementer.yml
@@ -93,6 +93,22 @@ jobs:
           echo "tools=$TOOLS" >> "$GITHUB_OUTPUT"
           echo "mcp_arg=$MCP_ARG" >> "$GITHUB_OUTPUT"
 
+      - name: Extract prior session
+        id: session
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          SESSION=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '[.comments[].body | select(startswith("<!-- session:critic:"))] | last | ltrimstr("<!-- session:critic:") | rtrimstr(" -->")' \
+            2>/dev/null || echo "")
+          if [ -n "$SESSION" ]; then
+            echo "resume_arg=--resume $SESSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "resume_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: claude
         uses: anthropics/claude-code-action@v1
         with:
@@ -100,10 +116,20 @@ jobs:
           github_token: ${{ secrets.GH_PAT }}
           claude_args: |
             --model claude-opus-4-6
+            ${{ steps.session.outputs.resume_arg }}
             --json-schema '{"type":"object","properties":{"status":{"type":"string","enum":["DONE","BLOCKED"]},"branch":{"type":"string"},"summary":{"type":"string"}},"required":["status","summary"]}'
             ${{ steps.setup.outputs.mcp_arg }}
             --allowed-tools "${{ steps.setup.outputs.tools }}"
           prompt: ${{ steps.setup.outputs.prompt }}
+
+      - name: Store session metadata
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "<!-- session:implementer:${{ steps.claude.outputs.session_id }} -->"
 
       - name: Swap labels
         env:
@@ -121,3 +147,16 @@ jobs:
               --remove-label "needs-impl" \
               --add-label "needs-verify"
           fi
+
+      - name: Handle stage failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "needs-impl" \
+            --add-label "pipeline-failed"
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "implementer stage failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -81,7 +81,8 @@ jobs:
           echo "tools=$TOOLS" >> "$GITHUB_OUTPUT"
           echo "mcp_arg=$MCP_ARG" >> "$GITHUB_OUTPUT"
 
-      - uses: anthropics/claude-code-action@v1
+      - id: claude
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
@@ -89,6 +90,15 @@ jobs:
             ${{ steps.setup.outputs.mcp_arg }}
             --allowed-tools "${{ steps.setup.outputs.tools }}"
           prompt: ${{ steps.setup.outputs.prompt }}
+
+      - name: Store session metadata
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "<!-- session:planner:${{ steps.claude.outputs.session_id }} -->"
 
       - name: Swap labels
         env:
@@ -98,3 +108,16 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label "needs-plan" \
             --add-label "needs-critique"
+
+      - name: Handle stage failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "needs-plan" \
+            --add-label "pipeline-failed"
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "planner stage failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -7,6 +7,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: read
   id-token: write
 
 jobs:
@@ -94,17 +95,44 @@ jobs:
           echo "tools=$TOOLS" >> "$GITHUB_OUTPUT"
           echo "mcp_arg=$MCP_ARG" >> "$GITHUB_OUTPUT"
 
+      - name: Extract prior session
+        id: session
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          SESSION=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json comments \
+            --jq '[.comments[].body | select(startswith("<!-- session:implementer:"))] | last | ltrimstr("<!-- session:implementer:") | rtrimstr(" -->")' \
+            2>/dev/null || echo "")
+          if [ -n "$SESSION" ]; then
+            echo "resume_arg=--resume $SESSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "resume_arg=" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GH_PAT }}
+          additional_permissions: "actions: read"
           claude_args: |
             --model claude-sonnet-4-6
+            ${{ steps.session.outputs.resume_arg }}
             --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL_RETRY","FAIL_ESCALATE"]},"summary":{"type":"string"}},"required":["verdict","summary"]}'
             ${{ steps.setup.outputs.mcp_arg }}
             --allowed-tools "${{ steps.setup.outputs.tools }}"
           prompt: ${{ steps.setup.outputs.prompt }}
+
+      - name: Store session metadata
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "<!-- session:verifier:${{ steps.claude.outputs.session_id }} -->"
 
       - name: Swap labels based on verification
         env:
@@ -138,3 +166,16 @@ jobs:
               --remove-label "needs-verify" \
               --add-label "needs-human"
           fi
+
+      - name: Handle stage failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "needs-verify" \
+            --add-label "pipeline-failed"
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "verifier stage failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/references/architecture/gha-pipeline.md
+++ b/references/architecture/gha-pipeline.md
@@ -22,6 +22,15 @@ Label swaps in critic, implementer, and verifier are driven by `structured_outpu
 - Every agent workflow gates on `sender.login == repository_owner AND issue.user.login == repository_owner`.
 - Each stage has a minimal `--allowed-tools` allowlist.
 
+## Failure recovery
+
+Each workflow has a `Handle stage failure` step with `if: failure()`. On any step failure it:
+1. Removes the trigger label (needs-plan, needs-critique, needs-impl, needs-verify).
+2. Adds `pipeline-failed`.
+3. Posts a comment with the workflow run URL.
+
+Known limitation: if `--resume` is passed with an expired server-side session, the claude step fails and triggers this handler rather than falling back to a fresh session. Re-add the trigger label to retry after the session expires. Graceful retry without resume is tracked as a follow-up.
+
 ## Models per stage
 
 | Stage | Model | Max turns |
@@ -41,6 +50,8 @@ Base tools per role. Additional tools are added by issue type label (see Label G
 | Critic | Read, Glob, Grep, Bash(gh issue view/comment) |
 | Implementer | Read, Glob, Grep, Edit, Write, Bash(git/npm/npx/tsx/python3/gh issue view/comment) |
 | Verifier | Read, Glob, Grep, Edit, Bash(git/npm/tsx/gh issue view/comment/gh pr create/merge) |
+
+Verifier also has `actions: read` permission for CI check-run access.
 
 ## Label groups
 

--- a/references/pipeline/labels.md
+++ b/references/pipeline/labels.md
@@ -25,3 +25,9 @@ Look at the files in the issue's Scope section:
 - Mixed or standard .ts/.json code? -> no type label
 
 If unsure, omit the type label. The default code path is safe for all issue types.
+
+## State labels (set automatically by pipeline)
+
+| Label | Meaning | Recovery |
+|-------|---------|----------|
+| pipeline-failed | A pipeline stage failed; trigger label removed, run link posted | Re-add the appropriate needs-* label after investigation |

--- a/references/pipeline/verifier.md
+++ b/references/pipeline/verifier.md
@@ -29,6 +29,9 @@ Check out the implementer's branch and update with master:
   git merge origin/master --no-edit
   git push
 
+0. CI status pre-check: `gh api repos/$GITHUB_REPOSITORY/commits/$(git rev-parse HEAD)/check-runs --jq '.check_runs[] | {name, status, conclusion}'`
+   If all relevant checks already show `conclusion: success`, skip step 4 (npm test).
+
 Verification checklist (complete ALL):
 
 1. Diff vs plan: `git diff master..HEAD`. Does every changed file


### PR DESCRIPTION
## Summary

- Adds session_id storage after each pipeline stage and `--resume` passing to subsequent stages for context continuity
- Adds `actions: read` permission to verifier for CI check-run access
- Adds deterministic `Handle stage failure` step to all four workflows to add `pipeline-failed` label on failures

## Changes

- `.github/workflows/planner.yml`, `critic.yml`, `implementer.yml`, `verifier.yml`: session continuity and failure handlers
- `references/architecture/gha-pipeline.md`: failure recovery section and verifier permissions note
- `references/pipeline/labels.md`: state labels table
- `references/pipeline/verifier.md`: CI pre-check step

Closes #184