### PR TITLE
web/test: migrate test files from require() to import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "aws-incident-simulator",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.91",
         "express": "^4.21.0",
@@ -17,6 +18,8 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.2",
         "acorn": "^8.16.0",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "commander": "^12.1.0",
         "connect-livereload": "^0.6.1",
         "livereload": "^0.10.3",

--- a/references/architecture/testing-system.md
+++ b/references/architecture/testing-system.md
@@ -223,7 +223,7 @@ spawnSync('tsx', ['--test', '--test-force-exit', testFile], { cwd: ROOT, ... })
 
 Why per-file:
 
-- The unit test files are `.ts` but use CommonJS `require()`. Plain `node --test` cannot resolve `require('../lib/progression')` against `web/lib/progression.ts`, so they must run under `tsx`.
+- Most test files have been migrated from `require()` to `import` (Issue #162). A few files retain `require()` for modules that read env vars at load time (`paths.ts`, `migrate-logs.ts`); these are documented inline. Plain `node --test` still cannot resolve bare `.ts` module paths, so tsx remains the test runtime. Smoke test alternative: `npx tsx --test --test-force-exit web/test/logger.test.ts` confirms ESM-only imports work outside the sim-test runner.
 - A single `tsx --test web/test/*.test.ts` invocation hangs when multiple files share one process (see inline comment at `scripts/test.ts:270`).
 - `--test-force-exit` ensures each subprocess exits even if a test leaves an open handle.
 

--- a/scripts/metrics.config.json
+++ b/scripts/metrics.config.json
@@ -32,7 +32,7 @@
     "sim": 278,
     "reference": 26,
     "registry": 4,
-    "config": 24,
+    "config": 25,
     "memory_link": 5
   },
   "budgets": {

--- a/web/test/agent-browser-summarize.test.ts
+++ b/web/test/agent-browser-summarize.test.ts
@@ -1,9 +1,9 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { spawnSync } = require('node:child_process');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'agent-browser-summarize.ts');

--- a/web/test/agent-test-runner.test.ts
+++ b/web/test/agent-test-runner.test.ts
@@ -1,7 +1,8 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { runAgentCheck, parseAgentJSON } from '../../scripts/agent-test-runner';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -13,8 +14,7 @@ describe('agent-test-runner', () => {
   });
 
   it('exports runAgentCheck function', () => {
-    const mod = require(sourcePath);
-    assert.equal(typeof mod.runAgentCheck, 'function');
+    assert.equal(typeof runAgentCheck, 'function');
   });
 
   it('hardcodes claude-sonnet-4-6', () => {
@@ -42,14 +42,12 @@ describe('agent-test-runner', () => {
   });
 
   it('parseAgentJSON extracts JSON from mixed text', () => {
-    const { parseAgentJSON } = require(sourcePath);
     const text = 'Some preamble\n```json\n{"pass": true, "findings": []}\n```\nMore text';
     const result = parseAgentJSON(text);
     assert.deepStrictEqual(result, { pass: true, findings: [] });
   });
 
   it('parseAgentJSON extracts bare JSON object', () => {
-    const { parseAgentJSON } = require(sourcePath);
     const text = '{"pass": false, "findings": [{"dimension": "summary", "pass": false, "detail": "wrong"}]}';
     const result = parseAgentJSON(text);
     assert.equal(result.pass, false);
@@ -57,7 +55,6 @@ describe('agent-test-runner', () => {
   });
 
   it('parseAgentJSON returns null for invalid input', () => {
-    const { parseAgentJSON } = require(sourcePath);
     assert.equal(parseAgentJSON('no json here'), null);
   });
 });

--- a/web/test/audit-permissions-hermeticity.test.ts
+++ b/web/test/audit-permissions-hermeticity.test.ts
@@ -1,8 +1,8 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const REGISTRY_PATH = 'references/registries/permission-bypass-registry.md';

--- a/web/test/audit-permissions.test.ts
+++ b/web/test/audit-permissions.test.ts
@@ -1,7 +1,8 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -11,7 +12,6 @@ describe('permission bypass audit', () => {
   });
 
   it('permission-bypass-registry.md exists after running audit', () => {
-    const { execSync } = require('child_process');
     execSync('npx tsx scripts/audit-permissions.ts', { cwd: ROOT, timeout: 60000 });
     assert.ok(fs.existsSync(path.join(ROOT, 'references', 'registries', 'permission-bypass-registry.md')));
   });
@@ -31,7 +31,6 @@ describe('permission bypass audit', () => {
   });
 
   it('running audit twice with no input changes leaves file untouched (PR-A.4.2)', () => {
-    const { execSync } = require('child_process');
     const registryPath = path.join(ROOT, 'references', 'registries', 'permission-bypass-registry.md');
     execSync('npx tsx scripts/audit-permissions.ts', { cwd: ROOT, timeout: 60000 });
     const firstContent = fs.readFileSync(registryPath, 'utf8');

--- a/web/test/build-agent-index.test.ts
+++ b/web/test/build-agent-index.test.ts
@@ -1,10 +1,10 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 'use strict';
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const INDEX_PATH = path.join(ROOT, 'references', 'registries', 'agent-index.md');

--- a/web/test/classify.test.ts
+++ b/web/test/classify.test.ts
@@ -1,9 +1,9 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classify, BUCKETS } from '../../scripts/lib/classify';
 'use strict';
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
 
-const { classify, BUCKETS } = require('../../scripts/lib/classify');
 
 const POSITIVE: Array<[string, string]> = [
   ['web/lib/paths.ts', 'code'],

--- a/web/test/claude-parse.test.ts
+++ b/web/test/claude-parse.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as claudeParse from '../lib/claude-parse';
 
-const claudeParse = require('../lib/claude-parse');
 
 describe('claude-parse exports', () => {
   it('exports parseEvents as a function', () => {

--- a/web/test/claude-process.test.ts
+++ b/web/test/claude-process.test.ts
@@ -1,16 +1,15 @@
-const { describe, it, beforeEach, afterEach, mock } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
+import { describe, it, beforeEach, afterEach, mock, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import { parseEvents, parseAgentMessages, logTurn, sendMessage, endSession, collectMessages, withRetry, buildPostSessionPrompt } from '../lib/claude-process';
+import { sessions } from '../lib/claude-session';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
 // --- parseEvents (marker extraction, unchanged logic) ---
 
 describe('parseEvents', () => {
-  // Lazy-load to allow mocking in other describe blocks
-  const { parseEvents } = require('../lib/claude-process');
-
   it('extracts text content', () => {
     const result = parseEvents('Hello, investigator.');
     assert.equal(result.events.length, 1);
@@ -67,8 +66,6 @@ describe('parseEvents', () => {
 // --- parseAgentMessages ---
 
 describe('parseAgentMessages', () => {
-  const { parseAgentMessages } = require('../lib/claude-process');
-
   it('extracts session_id from init message', () => {
     const messages = [
       { type: 'system', subtype: 'init', session_id: 'sess-abc' },
@@ -227,7 +224,6 @@ describe('parseAgentMessages', () => {
 // --- logTurn ---
 
 describe('logTurn', () => {
-  const { logTurn } = require('../lib/claude-process');
   const testSimId = '__test-turn-log__';
   const testDir = path.join(ROOT, 'learning', 'sessions', testSimId);
   const turnsPath = path.join(testDir, 'turns.jsonl');
@@ -271,8 +267,6 @@ describe('logTurn', () => {
 // --- sendMessage SESSION_LOST ---
 
 describe('sendMessage', () => {
-  const { sendMessage } = require('../lib/claude-process');
-
   it('throws SESSION_LOST for unknown sessionId', async () => {
     await assert.rejects(
       () => sendMessage('nonexistent-session-id', 'hello'),
@@ -288,9 +282,6 @@ describe('sendMessage', () => {
 // --- endSession ---
 
 describe('endSession', () => {
-  const { endSession } = require('../lib/claude-process');
-  const { sessions } = require('../lib/claude-session');
-
   it('silently handles nonexistent session', async () => {
     await endSession('nonexistent-session-xyz');
   });
@@ -310,8 +301,6 @@ describe('endSession', () => {
 // --- sessions map ---
 
 describe('sessions map', () => {
-  const { sessions } = require('../lib/claude-session');
-
   it('is exported and is a Map', () => {
     assert.ok(sessions instanceof Map);
   });
@@ -320,8 +309,6 @@ describe('sessions map', () => {
 // --- collectMessages timeout ---
 
 describe('collectMessages', () => {
-  const { collectMessages } = require('../lib/claude-process');
-
   it('collects messages from async generator', async () => {
     async function* generator() {
       yield { type: 'system', subtype: 'init', session_id: 's1' };
@@ -353,8 +340,6 @@ describe('collectMessages', () => {
 // --- parseAgentMessages error detection ---
 
 describe('parseAgentMessages error detection', () => {
-  const { parseAgentMessages } = require('../lib/claude-process');
-
   it('captures resultError from error result messages', () => {
     const messages = [
       { type: 'system', subtype: 'init', session_id: 's1' },
@@ -437,8 +422,6 @@ describe('cost budgeting', () => {
 // --- parseAgentMessages hasToolUse ---
 
 describe('parseAgentMessages hasToolUse', () => {
-  const { parseAgentMessages } = require('../lib/claude-process');
-
   it('returns hasToolUse: true when messages contain tool_use blocks', () => {
     const messages = [
       { type: 'assistant', message: { content: [
@@ -475,8 +458,6 @@ describe('streamMessage resume validation', () => {
 // --- withRetry ---
 
 describe('withRetry', () => {
-  const { withRetry } = require('../lib/claude-process');
-
   it('returns result on first success', async () => {
     const result = await withRetry(() => Promise.resolve('ok'));
     assert.equal(result, 'ok');
@@ -504,8 +485,6 @@ describe('withRetry', () => {
 // --- Post-session prompt includes solves pattern ---
 
 describe('buildPostSessionPrompt includes solves', () => {
-  const { buildPostSessionPrompt } = require('../lib/claude-process');
-
   it('prompt includes solves instruction', () => {
     // Use a known sim ID from registry
     const registry = JSON.parse(fs.readFileSync(path.join(ROOT, 'sims', 'registry.json'), 'utf8'));
@@ -543,8 +522,6 @@ describe('model is hardcoded', () => {
 // --- playtest transcript logging ---
 
 describe('playtest transcript logging', () => {
-  const { parseEvents } = require('../lib/claude-process');
-
   it('text can be split into narrator/console/coaching for transcripts', () => {
     const text = 'Narrator intro. [CONSOLE_START]{"sg": "sg-123"}[CONSOLE_END] Back to narrator.';
     const result = parseEvents(text);
@@ -565,5 +542,4 @@ describe('playtest transcript logging', () => {
 
 // Force exit after all tests complete: the Claude SDK import keeps open handles
 // that prevent the node --test runner from exiting within test's timeout.
-const { after } = require('node:test');
 after(() => setTimeout(() => process.exit(0), 500));

--- a/web/test/claude-session.test.ts
+++ b/web/test/claude-session.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as claudeSession from '../lib/claude-session';
 
-const claudeSession = require('../lib/claude-session');
 
 describe('claude-session exports', () => {
   it('exports sessions as a Map', () => {

--- a/web/test/claude-stream.test.ts
+++ b/web/test/claude-stream.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as claudeStream from '../lib/claude-stream';
 
-const claudeStream = require('../lib/claude-stream');
 
 describe('claude-stream exports', () => {
   it('exports streamQuery as an async generator function', () => {

--- a/web/test/code-health-config.test.ts
+++ b/web/test/code-health-config.test.ts
@@ -1,3 +1,8 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import { BUCKETS } from '../../scripts/lib/classify';
 'use strict';
 
 /**
@@ -11,16 +16,11 @@
  * metrics.config.json" cannot be done silently.
  */
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CONFIG_PATH = path.join(ROOT, 'scripts', 'metrics.config.json');
 const cfg = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
 
-const { BUCKETS } = require('../../scripts/lib/classify');
 
 describe('metrics.config.json', () => {
   it('exists and is valid JSON', () => {

--- a/web/test/code-health.test.ts
+++ b/web/test/code-health.test.ts
@@ -1,16 +1,16 @@
-'use strict';
-
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
-const acorn = require('acorn');
-
-const {
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import acorn from 'acorn';
+import cfg from '../../scripts/metrics.config.json';
+import { classify, BUCKETS } from '../../scripts/lib/classify';
+import {
   parseFile, walk, extractRequires, extractExportCount, computeComplexity,
   scoreModularity, scoreEncapsulation, scoreSizeBalance,
-  scoreDepDepth, scoreComplexity, scoreTestSync, loadWeights, main, round
-} = require('../../scripts/code-health');
+  scoreDepDepth, scoreComplexity, scoreTestSync, loadWeights, main, round,
+  discoverScope, scoreAllBuckets, scoreLayer34,
+} from '../../scripts/code-health';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const TMP_DIR = path.join(ROOT, 'learning', 'logs', '_health_test_tmp');
@@ -394,12 +394,6 @@ describe('round', () => {
 // PR-C invariants and anti-gaming guardrails
 // ---------------------------------------------------------------------------
 
-const {
-  classify, BUCKETS,
-} = require('../../scripts/lib/classify');
-const {
-  discoverScope, scoreAllBuckets,
-} = require('../../scripts/code-health');
 
 function emptyDiscovery() {
   const byBucket = Object.fromEntries(BUCKETS.map(b => [b, []]));
@@ -533,7 +527,6 @@ describe('anti-gaming scenarios (12 rows from PR-C plan)', () => {
   });
 
   it('A7 (lower the bar in config): bucketWeights are equal across all 10 buckets', () => {
-    const cfg = require('../../scripts/metrics.config.json');
     const expected = 1 / BUCKETS.length;
     for (const v of Object.values(cfg.bucketWeights)) {
       assert.ok(Math.abs((v as number) - expected) < 0.001);
@@ -545,11 +538,9 @@ describe('anti-gaming scenarios (12 rows from PR-C plan)', () => {
   });
 
   it('A9 (delete health-scores.jsonl): the canonical path is constant and recreated', () => {
-    const fsX = require('fs');
-    const pathX = require('path');
-    const expected = pathX.join(__dirname, '..', '..', 'learning', 'logs', 'health-scores.jsonl');
+    const expected = path.join(__dirname, '..', '..', 'learning', 'logs', 'health-scores.jsonl');
     main();
-    assert.ok(fsX.existsSync(expected));
+    assert.ok(fs.existsSync(expected));
   });
 
   it('A10 (add a new bucket): BUCKETS list is exactly the 10 PR-C buckets', () => {
@@ -608,7 +599,6 @@ describe('plans are invisible to the scorer', () => {
 // PR-D Layer 3+4 aggregation: scoreLayer34, ranked findings, JSON shape
 // ---------------------------------------------------------------------------
 
-const { scoreLayer34 } = require('../../scripts/code-health');
 
 describe('Layer 3+4 aggregation', () => {
   it('returns ranked findings sorted by point impact, deterministic', () => {

--- a/web/test/core-workflow-doc.test.ts
+++ b/web/test/core-workflow-doc.test.ts
@@ -1,9 +1,9 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 'use strict';
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const DOC = path.join(ROOT, 'references', 'architecture', 'core-workflow.md');

--- a/web/test/cross-file-consistency.test.ts
+++ b/web/test/cross-file-consistency.test.ts
@@ -1,10 +1,10 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { loadConfig, axisNames } from '../lib/progression';
 
-const { loadConfig, axisNames } = require('../lib/progression');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CONFIG_PATH = path.join(ROOT, 'references', 'config', 'progression.yaml');

--- a/web/test/doctor.test.ts
+++ b/web/test/doctor.test.ts
@@ -1,3 +1,9 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { checkRawLogAppendable, checkSystemVaultPresent, checkScheduledJobs, checkMcpConfig, checkPostCommitHook, checkHealthScoreRecent, checkPathRegistryFresh, checkSimTestSmoke, checkWebServerBoot, checkSkillDanglingRefs, checkPathRegistryHashFresh, formatCheckLine, runAll } from '../../scripts/doctor';
 // Tests for scripts/doctor.ts (Group F of plan
 // .claude/plans/replicated-exploring-thompson.md, Issue #96).
 //
@@ -8,27 +14,7 @@
 // exact actionable path/command in the detail string. The user's
 // requirement is that any FAIL must point at the fix.
 
-const { describe, it, before, after } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const os = require('node:os');
-const path = require('node:path');
 
-const {
-  checkRawLogAppendable,
-  checkSystemVaultPresent,
-  checkScheduledJobs,
-  checkMcpConfig,
-  checkPostCommitHook,
-  checkHealthScoreRecent,
-  checkPathRegistryFresh,
-  checkSimTestSmoke,
-  checkWebServerBoot,
-  checkSkillDanglingRefs,
-  checkPathRegistryHashFresh,
-  formatCheckLine,
-  runAll,
-} = require('../../scripts/doctor');
 
 // ---------------------------------------------------------------------------
 // Fixture helpers

--- a/web/test/eval-runner.test.ts
+++ b/web/test/eval-runner.test.ts
@@ -1,8 +1,9 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import * as evalRunner from '../../scripts/eval-runner';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -80,7 +81,6 @@ describe('eval scoring spec', () => {
 // Eval runner tests
 // ---------------------------------------------------------------------------
 
-const evalRunner = require('../../scripts/eval-runner');
 
 describe('eval runner: loadScoringSpec', () => {
   it('loads and returns spec with categories', () => {

--- a/web/test/frontmatter.test.ts
+++ b/web/test/frontmatter.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripFrontmatter } from '../lib/frontmatter';
 
-const { stripFrontmatter } = require('../lib/frontmatter');
 
 describe('stripFrontmatter', () => {
   it('returns body and empty meta when no frontmatter', () => {

--- a/web/test/game-session.test.ts
+++ b/web/test/game-session.test.ts
@@ -1,7 +1,7 @@
-const { describe, it, beforeEach, afterEach, after } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
+import { describe, it, beforeEach, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -31,6 +31,8 @@ const sessionPath = path.join(testDir, 'session.json');
 // --- createGameSession ---
 
 describe('createGameSession', () => {
+  // require() preserved: must run after AWS_SIMULATOR_SESSIONS_DIR is set above.
+  // Hoisting this import would cause paths.ts to load before the env var is set.
   const { createGameSession } = require('../lib/claude-session');
 
   beforeEach(() => {
@@ -121,6 +123,7 @@ describe('createGameSession', () => {
 // --- updateGameSession ---
 
 describe('updateGameSession', () => {
+  // require() preserved: must run after AWS_SIMULATOR_SESSIONS_DIR is set above.
   const { updateGameSession, createGameSession } = require('../lib/claude-session');
 
   afterEach(() => {
@@ -165,6 +168,7 @@ describe('updateGameSession', () => {
 // --- runPostSessionAgent ---
 
 describe('runPostSessionAgent', () => {
+  // require() preserved: must run after AWS_SIMULATOR_SESSIONS_DIR is set above.
   const { runPostSessionAgent } = require('../lib/claude-process');
 
   it('function exists and is exported', () => {
@@ -177,6 +181,7 @@ describe('runPostSessionAgent', () => {
 });
 
 describe('buildPostSessionPrompt', () => {
+  // require() preserved: must run after AWS_SIMULATOR_SESSIONS_DIR is set above.
   const { buildPostSessionPrompt } = require('../lib/claude-process');
 
   it('prompt contains required file paths', () => {

--- a/web/test/git-commit-format.test.ts
+++ b/web/test/git-commit-format.test.ts
@@ -1,5 +1,5 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 
 /**
  * Validates commit message format against the contextual commits spec.

--- a/web/test/graph-metrics.test.ts
+++ b/web/test/graph-metrics.test.ts
@@ -1,22 +1,16 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { proseDuplication, danglingReferences, activityFreshness, skillOwnershipIntegrity, dedupeOwnershipFindings } from '../../scripts/lib/graph-metrics';
 'use strict';
 
 // Tests for scripts/lib/graph-metrics.ts (PR-D Layers 3+4).
 // Pure unit tests over inline string fixtures and tmp dirs. No git, no
 // real raw.jsonl. Each metric: positive case, negative case, edge case.
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
 
-const {
-  proseDuplication,
-  danglingReferences,
-  activityFreshness,
-  skillOwnershipIntegrity,
-  dedupeOwnershipFindings,
-} = require('../../scripts/lib/graph-metrics');
 
 function mkTmp(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), `gm-${prefix}-`));

--- a/web/test/guard-coverage.test.ts
+++ b/web/test/guard-coverage.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const GUARD_PATH = path.join(ROOT, '.claude', 'hooks', 'guard-write.ts');

--- a/web/test/guard-write.test.ts
+++ b/web/test/guard-write.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('node:path');
-const { checkAccess } = require('../../.claude/hooks/guard-write');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { checkAccess } from '../../.claude/hooks/guard-write';
 
 const ROOT = '/tmp/aws-test-root';
 

--- a/web/test/headless-allowlist.test.ts
+++ b/web/test/headless-allowlist.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 // Drift check for Issue #127: every Edit(...) path the
 // .claude/settings.json permissions.allow list exposes to headless

--- a/web/test/health-floors.test.ts
+++ b/web/test/health-floors.test.ts
@@ -1,3 +1,7 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreAllBuckets } from '../../scripts/code-health';
+import { BUCKETS } from '../../scripts/lib/classify';
 'use strict';
 
 /**
@@ -7,13 +11,7 @@
  * unless --rebase-floors is passed. Going below the floor zeros the bucket.
  */
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
 
-const {
-  scoreAllBuckets,
-} = require('../../scripts/code-health');
-const { BUCKETS } = require('../../scripts/lib/classify');
 
 function makeDiscovery(byBucket: Record<string, string[]>) {
   const full: Record<string, string[]> = Object.fromEntries(BUCKETS.map((b: string) => [b, []]));

--- a/web/test/hook-permissions.test.ts
+++ b/web/test/hook-permissions.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const SETTINGS_PATH = path.join(ROOT, '.claude', 'settings.json');

--- a/web/test/log-hook.test.ts
+++ b/web/test/log-hook.test.ts
@@ -1,6 +1,6 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { buildRecord, logFileName } = require('../../.claude/hooks/log-hook');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRecord, logFileName } from '../../.claude/hooks/log-hook';
 
 describe('buildRecord', () => {
   it('always includes base fields', () => {

--- a/web/test/log-rotation.test.ts
+++ b/web/test/log-rotation.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { canRotate } from '../lib/system-vault';
 
-const { canRotate } = require('../lib/system-vault');
 
 describe('log rotation: only-referenced rotation', () => {
   it('allows rotation of an unreferenced archive older than 7 days', () => {

--- a/web/test/logger.test.ts
+++ b/web/test/logger.test.ts
@@ -1,10 +1,11 @@
-const { describe, it, before, after } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import paths from '../lib/paths';
+import { logEvent, generateFixManifest, sessionTraces } from '../lib/logger';
 
-const paths = require('../lib/paths');
 
 // PR-B unification: there is now a single raw.jsonl. The legacy LOG_FILE
 // and SYSTEM_LOG_FILE constants alias to RAW_LOG_FILE; tests that used to
@@ -16,7 +17,6 @@ paths.RAW_LOG_FILE = tmpRawLogFile;
 paths.LOG_FILE = tmpRawLogFile;
 paths.SYSTEM_LOG_FILE = tmpRawLogFile;
 
-const { logEvent, generateFixManifest, sessionTraces } = require('../lib/logger');
 
 const RAW_LOG_FILE = tmpRawLogFile;
 

--- a/web/test/markdown.test.ts
+++ b/web/test/markdown.test.ts
@@ -1,9 +1,9 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { renderMarkdown } from '../public/markdown.ts';
 
-const { renderMarkdown } = require('../public/markdown.ts');
 
 describe('renderMarkdown', () => {
   // In Node.js test environment, marked is not loaded (CDN-only).

--- a/web/test/migrate-logs.test.ts
+++ b/web/test/migrate-logs.test.ts
@@ -1,8 +1,9 @@
-const { describe, it, beforeEach, after } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 
 // PR-B step 2: tests for the activity.jsonl + system.jsonl -> raw.jsonl
 // migration. Every test runs against a tmp logs dir wired through the
@@ -11,6 +12,8 @@ const path = require('path');
 
 const tmpRoot: string = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-logs-test-'));
 process.env.AWS_SIMULATOR_LOGS_DIR = tmpRoot;
+// require() preserved: migrate-logs.ts reads AWS_SIMULATOR_LOGS_DIR at module load time.
+// Hoisting this import would cause it to load before the env var is set above.
 const { migrate } = require('../../scripts/migrate-logs');
 
 after(() => {

--- a/web/test/migration.test.ts
+++ b/web/test/migration.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/web/test/model-split.test.ts
+++ b/web/test/model-split.test.ts
@@ -1,13 +1,13 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as claudeProcess from '../lib/claude-process.ts';
 // Asserts the Sonnet/Opus model split is hardcoded via named constants,
 // not inline literals. See Issue #107. Sonnet drives interactive play,
 // Opus runs post-session scoring. Do not flip without an A/B on quality.
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
 
-const claudeProcess = require('../lib/claude-process.ts');
 
 describe('model split constants', () => {
   it('exports PLAY_SESSION_MODEL as claude-sonnet-4-6', () => {

--- a/web/test/path-registry.test.ts
+++ b/web/test/path-registry.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CSV_PATH = path.join(ROOT, 'references', 'registries', 'path-registry.csv');

--- a/web/test/paths.test.ts
+++ b/web/test/paths.test.ts
@@ -1,7 +1,7 @@
-const assert = require('node:assert/strict');
-const { describe, it } = require('node:test');
-const path = require('path');
-const paths = require('../lib/paths');
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import path from 'path';
+import paths from '../lib/paths';
 
 describe('paths', () => {
   describe('static paths', () => {

--- a/web/test/permission-contracts.test.ts
+++ b/web/test/permission-contracts.test.ts
@@ -1,11 +1,10 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs, { globSync } from 'fs';
+import path from 'path';
 // Permission contracts test suite
 // Validates security invariants across tool whitelists, hook wiring, and guard-write rules.
 // See: https://github.com/drashti-shah/aws-simulator/issues/24
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const { globSync } = require('fs');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/web/test/pre-commit-issues.test.ts
+++ b/web/test/pre-commit-issues.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { spawnSync } = require('node:child_process');
-const path = require('node:path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const HOOK = path.join(ROOT, '.claude', 'hooks', 'pre-commit-issues.ts');

--- a/web/test/pre-commit-ui-tests.test.ts
+++ b/web/test/pre-commit-ui-tests.test.ts
@@ -1,8 +1,8 @@
-const { describe, it, before, after } = require('node:test');
-const assert = require('node:assert/strict');
-const { spawnSync, execSync } = require('node:child_process');
-const fs = require('node:fs');
-const path = require('node:path');
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const HOOK = path.join(ROOT, '.claude', 'hooks', 'pre-commit-ui-tests.ts');

--- a/web/test/progress.test.ts
+++ b/web/test/progress.test.ts
@@ -1,13 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getQuestionTypes, currentRank, normalizeHexagon, parseCatalog, serviceProgress } from '../lib/progress';
 
-const {
-  getQuestionTypes,
-  currentRank,
-  normalizeHexagon,
-  parseCatalog,
-  serviceProgress
-} = require('../lib/progress');
 
 describe('getQuestionTypes', () => {
   it('has six types', () => {

--- a/web/test/progression.test.ts
+++ b/web/test/progression.test.ts
@@ -1,21 +1,8 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { loadConfig, axisNames, evaluateGate, currentRank, maxDifficulty, applyDecay, scoreSim, availableModifiers, normalizePolygon, initPolygon, applyDiminishingReturns, evaluateQualityGate } from '../lib/progression';
 
-const {
-  loadConfig,
-  axisNames,
-  evaluateGate,
-  currentRank,
-  maxDifficulty,
-  applyDecay,
-  scoreSim,
-  availableModifiers,
-  normalizePolygon,
-  initPolygon,
-  applyDiminishingReturns,
-  evaluateQualityGate,
-} = require('../lib/progression');
 
 const CONFIG_PATH = path.join(__dirname, '..', '..', 'references', 'config', 'progression.yaml');
 

--- a/web/test/prompt-builder.test.ts
+++ b/web/test/prompt-builder.test.ts
@@ -1,9 +1,9 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import { buildPrompt } from '../lib/prompt-builder';
 
-const { buildPrompt } = require('../lib/prompt-builder');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/web/test/question-quality.test.ts
+++ b/web/test/question-quality.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { qualityFactor, updateRunningAverage } from '../lib/question-quality';
 
-const { qualityFactor, updateRunningAverage } = require('../lib/question-quality');
 
 describe('qualityFactor', () => {
   it('returns 0.25 when avgQuality is 0', () => {

--- a/web/test/references-health.test.ts
+++ b/web/test/references-health.test.ts
@@ -1,11 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import { scoreReferencesHealth, main } from '../../scripts/code-health';
 'use strict';
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
 
-const { scoreReferencesHealth } = require('../../scripts/code-health');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -70,7 +70,6 @@ describe('scoreReferencesHealth', () => {
 
 describe('main composite includes references_health', () => {
   it('reports references_health in the scores object', () => {
-    const { main } = require('../../scripts/code-health');
     // Capture stdout to silence
     const origLog = console.log;
     console.log = () => {};

--- a/web/test/scheduled-jobs-boundary.test.ts
+++ b/web/test/scheduled-jobs-boundary.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const JOBS_DIR = path.join(ROOT, '.claude', 'scheduled-jobs');

--- a/web/test/server.test.ts
+++ b/web/test/server.test.ts
@@ -1,11 +1,11 @@
-const { describe, it, before, after, beforeEach } = require('node:test');
-const assert = require('node:assert/strict');
-const http = require('http');
-const path = require('path');
-const fs = require('fs');
-const express = require('express');
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'http';
+import path from 'path';
+import fs from 'fs';
+import express from 'express';
+import { currentRank, normalizeHexagon, parseCatalog, getQuestionTypes, getConfig, progression } from '../lib/progress';
 
-const { currentRank, normalizeHexagon, parseCatalog, getQuestionTypes, getConfig, progression } = require('../lib/progress');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/web/test/session-persistence.test.ts
+++ b/web/test/session-persistence.test.ts
@@ -1,7 +1,7 @@
-const { describe, it, beforeEach, afterEach, after } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('path');
-const fs = require('fs');
+import { describe, it, beforeEach, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -11,6 +11,9 @@ const TMP_SESSIONS_DIR = path.join(__dirname, '.tmp', `session-persistence-${pro
 process.env.AWS_SIMULATOR_SESSIONS_DIR = TMP_SESSIONS_DIR;
 fs.mkdirSync(TMP_SESSIONS_DIR, { recursive: true });
 
+// require() preserved for paths and claude-session: must run after
+// AWS_SIMULATOR_SESSIONS_DIR is set above. ESM imports are hoisted before
+// module-level code, which would cause paths.ts to load without the env var.
 const paths = require('../lib/paths');
 const { persistSession, recoverSessions, sessions, SESSION_MAX_AGE_MS } = require('../lib/claude-session');
 
@@ -77,6 +80,8 @@ describe('recoverSessions', () => {
   const realSimId = '001-ec2-unreachable';
   const testDir = paths.sessionDir(realSimId);
   const filePath = path.join(testDir, 'web-session.json');
+  // require() preserved: prompt-builder imports paths; must run after env var is set.
+  const { buildPrompt } = require('../lib/prompt-builder');
 
   beforeEach(() => {
     // Clear sessions map
@@ -106,7 +111,7 @@ describe('recoverSessions', () => {
       turnCount: 3
     }));
 
-    recoverSessions(require('../lib/prompt-builder').buildPrompt);
+    recoverSessions(buildPrompt);
     assert.ok(sessions.has('recover-1'), 'session should be recovered');
     const session = sessions.get('recover-1');
     assert.equal(session.simId, realSimId);
@@ -125,7 +130,7 @@ describe('recoverSessions', () => {
       turnCount: 0
     }));
 
-    recoverSessions(require('../lib/prompt-builder').buildPrompt);
+    recoverSessions(buildPrompt);
     const session = sessions.get('recover-fields');
     assert.ok(session, 'session should exist');
     assert.ok(session.claudeSessionId);
@@ -149,7 +154,7 @@ describe('recoverSessions', () => {
       turnCount: 10
     }));
 
-    recoverSessions(require('../lib/prompt-builder').buildPrompt);
+    recoverSessions(buildPrompt);
     assert.ok(!sessions.has('recover-old'), 'old session should not be recovered');
   });
 
@@ -157,7 +162,7 @@ describe('recoverSessions', () => {
     fs.writeFileSync(filePath, '{invalid json!!!');
 
     // Should not throw
-    recoverSessions(require('../lib/prompt-builder').buildPrompt);
+    recoverSessions(buildPrompt);
     assert.equal(sessions.size, 0, 'no sessions recovered from corrupt file');
   });
 
@@ -187,7 +192,7 @@ describe('recoverSessions', () => {
       turnCount: 0
     }));
 
-    recoverSessions(require('../lib/prompt-builder').buildPrompt);
+    recoverSessions(buildPrompt);
     assert.ok(!sessions.has('recover-missing'), 'session with missing sim should not be recovered');
 
     // Cleanup
@@ -196,6 +201,7 @@ describe('recoverSessions', () => {
 });
 
 describe('endSession cleanup', () => {
+  // require() preserved: claude-process imports paths; must run after env var is set.
   const { endSession } = require('../lib/claude-process');
   const testSimId = '__test-end-cleanup__';
   const testDir = paths.sessionDir(testSimId);

--- a/web/test/setup-consistency.test.ts
+++ b/web/test/setup-consistency.test.ts
@@ -1,9 +1,9 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { loadConfig, axisNames, currentRank } from '../lib/progression';
 
-const { loadConfig, axisNames, currentRank } = require('../lib/progression');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CONFIG_PATH = path.join(ROOT, 'references', 'config', 'progression.yaml');

--- a/web/test/streaming.test.ts
+++ b/web/test/streaming.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 

--- a/web/test/system-vault.test.ts
+++ b/web/test/system-vault.test.ts
@@ -1,23 +1,10 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { VAULT_SUBDIRS, layout, INDEX_MAX_LINES, TOPIC_FILE_MAX_BYTES, QUERY_MAX_FILES_PER_TURN, QUERY_MAX_BYTES_PER_TURN, QUERY_MAX_BYTES_PER_SESSION, checkIndex, checkTopicSizes, QueryBudget, DREAM_PHASES, validateDreamPlan } from '../lib/system-vault';
 
-const {
-  VAULT_SUBDIRS,
-  layout,
-  INDEX_MAX_LINES,
-  TOPIC_FILE_MAX_BYTES,
-  QUERY_MAX_FILES_PER_TURN,
-  QUERY_MAX_BYTES_PER_TURN,
-  QUERY_MAX_BYTES_PER_SESSION,
-  checkIndex,
-  checkTopicSizes,
-  QueryBudget,
-  DREAM_PHASES,
-  validateDreamPlan,
-} = require('../lib/system-vault');
 
 function makeVault(): { root: string; learning: string } {
   const learning = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-learning-'));

--- a/web/test/test-checks.test.ts
+++ b/web/test/test-checks.test.ts
@@ -1,15 +1,15 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 // Tests for the new browser-spec check types: console_clean, network_ok, landmarks_present.
 // The test runner is an agent-instruction translator: it parses YAML specs and prints
 // step-by-step instructions for a chrome-devtools-driving subagent. These tests assert that
 // the schema accepts the new check types and that the agent printer renders them correctly,
 // including spec-level allowlists and origin lists.
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { execSync } = require('child_process');
-const fs = require('node:fs');
-const path = require('node:path');
-const os = require('node:os');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CLI = 'npx tsx scripts/test.ts';

--- a/web/test/test-cli.test.ts
+++ b/web/test/test-cli.test.ts
@@ -1,7 +1,7 @@
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { execSync } = require('child_process');
-const path = require('path');
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import path from 'path';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const CLI = 'npx tsx scripts/test.ts';

--- a/web/test/test-run.test.ts
+++ b/web/test/test-run.test.ts
@@ -1,3 +1,6 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTestOutput, aggregateRuns, formatFailedFilesSummary } from '../../scripts/test-runner';
 // Tests for test run failing-file reporting helpers (Group A of plan
 // .claude/plans/replicated-exploring-thompson.md, Issue #92).
 //
@@ -6,14 +9,7 @@
 // unit-tested without invoking the real CLI. Integration is verified by the
 // manual step in the plan: break web/test/markdown.test.ts and run npm test.
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
 
-const {
-  parseTestOutput,
-  aggregateRuns,
-  formatFailedFilesSummary,
-} = require('../../scripts/test-runner');
 
 describe('parseTestOutput', () => {
   it('parses node:test "# pass N / # fail N" output', () => {

--- a/web/test/test-runner.test.ts
+++ b/web/test/test-runner.test.ts
@@ -1,15 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { filterByGlob, mapChangedToTests, globToRegExp } from '../../scripts/test-select';
 // Tests for test run selection helpers: --files <glob> and --changed.
 // These cover pure selection logic in scripts/test-select.ts.
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const path = require('node:path');
 
-const {
-  filterByGlob,
-  mapChangedToTests,
-  globToRegExp,
-} = require('../../scripts/test-select');
 
 describe('test selection: globToRegExp', () => {
   it('matches literal file names', () => {

--- a/web/test/transcript.test.ts
+++ b/web/test/transcript.test.ts
@@ -1,14 +1,14 @@
-const { describe, it, beforeEach, afterEach } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import paths from '../lib/paths';
+import * as transcript from '../lib/transcript';
 
 // --- paths.js changes ---
 
 describe('paths: session directory structure', () => {
-  const paths = require('../lib/paths');
-
   it('sessionFile returns {id}/session.json path', () => {
     const result = paths.sessionFile('001-ec2-unreachable');
     assert.ok(result.endsWith(path.join('001-ec2-unreachable', 'session.json')));
@@ -29,17 +29,15 @@ describe('paths: session directory structure', () => {
 
 describe('transcript module', () => {
   let tmpDir;
-  let transcript;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sim-transcript-'));
-    transcript = require('../lib/transcript');
     transcript._setSessionsDir(tmpDir);
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    delete require.cache[require.resolve('../lib/transcript')];
+    // delete require.cache removed: _setSessionsDir in beforeEach provides sufficient isolation.
   });
 
   it('appendTurn creates directory and writes JSONL', () => {

--- a/web/test/vault.test.ts
+++ b/web/test/vault.test.ts
@@ -1,9 +1,10 @@
-const { describe, it, before } = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import paths from '../lib/paths';
+import { qualityFactor, updateRunningAverage } from '../lib/question-quality';
 
-const paths = require('../lib/paths');
 const ROOT = paths.ROOT;
 const VAULT_DIR = paths.VAULT_DIR;
 
@@ -160,10 +161,6 @@ describe('vault template content', () => {
 });
 
 describe('question quality scoring', () => {
-  const { qualityFactor, updateRunningAverage } = (() => {
-    try { return require('../lib/question-quality'); } catch { return {}; }
-  })();
-
   it('qualityFactor: quality 0 returns 0.25 (floor)', () => {
     if (!qualityFactor) return;
     assert.equal(qualityFactor(0), 0.25);

--- a/web/test/workflow-references.test.ts
+++ b/web/test/workflow-references.test.ts
@@ -1,9 +1,9 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import path from 'path';
 'use strict';
 
-const { describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const { execSync } = require('node:child_process');
-const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 


### PR DESCRIPTION
Closes #162

Converts 55 `web/test/*.test.ts` files from CommonJS `require()` to ESM `import`. Mechanical conversions for 49 files; 6 handled manually for special cases.

Documented exceptions retain `require()` where ESM hoisting would cause `paths.ts` or `migrate-logs.ts` to load before env vars are set. All exceptions annotated inline.

Also updates `references/architecture/testing-system.md` with smoke test note per plan scope.

879/879 tests pass.