### PR TITLE
Drop reflector --max-turns 10 cap + fix stale vault test

### DIFF
--- a/.github/workflows/reflector.yml
+++ b/.github/workflows/reflector.yml
@@ -73,7 +73,6 @@ jobs:
           github_token: ${{ secrets.GH_PAT }}
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 10
             --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["CREATED","UPDATED","NOOP"]},"summary":{"type":"string"},"files":{"type":"array","items":{"type":"string"}},"loop_detected":{"type":"boolean"}},"required":["verdict","summary","files","loop_detected"]}'
             --allowed-tools "${{ steps.setup.outputs.tools }}"
           prompt: ${{ steps.setup.outputs.prompt }}

--- a/web/test/vault.test.ts
+++ b/web/test/vault.test.ts
@@ -77,22 +77,11 @@ describe('setup SKILL.md vault wiring (Issue #94)', () => {
     }
   });
 
-  it('vault seed snippets use mkdir -p under the vault dirs', () => {
-    // Step 5b/5c should set up the two vaults via a Bash mkdir -p block.
-    // Both player-vault and system-vault must appear in a mkdir -p line so
-    // guard-write's Write/Edit block is bypassed.
+  it('player-vault seed snippet uses mkdir -p under the vault dir', () => {
     const mkdirMatches = skill.match(/mkdir -p (learning\/[a-z-]+-vault[^\n]*)/g) ?? [];
-    assert.ok(
-      mkdirMatches.length >= 2,
-      'expected at least two mkdir -p lines for the vault seeds, found ' + mkdirMatches.length,
-    );
     assert.ok(
       mkdirMatches.some((l) => l.includes('learning/player-vault')),
       'expected a mkdir -p line for learning/player-vault',
-    );
-    assert.ok(
-      mkdirMatches.some((l) => l.includes('learning/system-vault')),
-      'expected a mkdir -p line for learning/system-vault',
     );
   });
 });


### PR DESCRIPTION
Closes #199

## Summary
- Deletes the only `--max-turns` cap in the pipeline (`.github/workflows/reflector.yml:76`). Every other stage (planner, critic, implementer, verifier) omits it. Issue #195's reflector died at num_turns=11 against the cap; the legitimate CREATE path needs ~15 tool calls.
- Fixes a stale test assertion in `web/test/vault.test.ts` that broke master after commit 85d35fa removed the system-vault bootstrap from the setup skill (closes #196 aftermath). The test still expected two mkdir -p lines; only player-vault needs bootstrapping now.

## Test plan
- [x] `npx tsx scripts/test.ts run --files web/test/vault.test.ts`: 21/21 pass (was 20/21).
- [x] `npx tsx scripts/test.ts run`: 858/858 pass.
- [x] `npx tsx scripts/audit-permissions.ts`: registry unchanged.
- [x] YAML parses: `npx js-yaml .github/workflows/reflector.yml`.
- [ ] Verify on next reflector run (after a real pipeline issue merges).