### PR TITLE
fix(workflows): allowlist claude[bot] in close-foreign-issues

### DIFF
--- a/.github/workflows/close-foreign-issues.yml
+++ b/.github/workflows/close-foreign-issues.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   close:
-    if: github.event.issue.user.login != github.repository_owner
+    if: >-
+      github.event.issue.user.login != github.repository_owner
+      && github.event.issue.user.login != 'claude[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- close-foreign-issues.yml was closing pipeline-authored child issues (author `claude[bot]` via `GH_PAT`), not just foreign human submissions.
- Two false positives observed: #232 and #255 (both labeled `decomposed-from`), closed moments after the planner spawned them.
- Allowlist the specific `claude[bot]` login (not all bots); any other author still gets closed.

Closes #258.

## Test plan

- [ ] Next planner decomposition leaves child issues open.
- [ ] A foreign-authored issue (non-owner, non-`claude[bot]`) still gets auto-closed.