### PR TITLE
fix(workflows): allowlist claude[bot] in pipeline gates

### DIFF
--- a/.github/workflows/critic.yml
+++ b/.github/workflows/critic.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       github.event.label.name == 'needs-critique' &&
       github.event.sender.login == github.repository_owner &&
-      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.user.login == github.repository_owner || github.event.issue.user.login == 'claude[bot]') &&
       !contains(github.event.issue.labels.*.name, 'blocked') &&
       !contains(github.event.issue.labels.*.name, 'cancel') &&
       !contains(github.event.issue.labels.*.name, 'needs-human')

--- a/.github/workflows/evaluator.yml
+++ b/.github/workflows/evaluator.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event.label.name == 'needs-eval' &&
       github.event.sender.login == github.repository_owner &&
-      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.user.login == github.repository_owner || github.event.issue.user.login == 'claude[bot]') &&
       !contains(github.event.issue.labels.*.name, 'blocked') &&
       !contains(github.event.issue.labels.*.name, 'cancel') &&
       !contains(github.event.issue.labels.*.name, 'pipeline-failed')

--- a/.github/workflows/implementer.yml
+++ b/.github/workflows/implementer.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       github.event.label.name == 'needs-impl' &&
       github.event.sender.login == github.repository_owner &&
-      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.user.login == github.repository_owner || github.event.issue.user.login == 'claude[bot]') &&
       !contains(github.event.issue.labels.*.name, 'blocked') &&
       !contains(github.event.issue.labels.*.name, 'cancel') &&
       !contains(github.event.issue.labels.*.name, 'needs-human')

--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -13,7 +13,7 @@ jobs:
     if: |
       github.event.label.name == 'needs-plan' &&
       github.event.sender.login == github.repository_owner &&
-      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.user.login == github.repository_owner || github.event.issue.user.login == 'claude[bot]') &&
       !contains(github.event.issue.labels.*.name, 'blocked') &&
       !contains(github.event.issue.labels.*.name, 'cancel') &&
       !contains(github.event.issue.labels.*.name, 'needs-human')

--- a/.github/workflows/verifier.yml
+++ b/.github/workflows/verifier.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.label.name == 'needs-verify' &&
       github.event.sender.login == github.repository_owner &&
-      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.user.login == github.repository_owner || github.event.issue.user.login == 'claude[bot]') &&
       !contains(github.event.issue.labels.*.name, 'blocked') &&
       !contains(github.event.issue.labels.*.name, 'cancel') &&
       !contains(github.event.issue.labels.*.name, 'needs-human')

--- a/web/test/pipeline-label-routing.test.ts
+++ b/web/test/pipeline-label-routing.test.ts
@@ -11,6 +11,15 @@ const plannerYml = fs.readFileSync(
 const criticYml = fs.readFileSync(
   path.join(ROOT, '.github', 'workflows', 'critic.yml'), 'utf8'
 );
+const implementerYml = fs.readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'implementer.yml'), 'utf8'
+);
+const verifierYml = fs.readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'verifier.yml'), 'utf8'
+);
+const evaluatorYml = fs.readFileSync(
+  path.join(ROOT, '.github', 'workflows', 'evaluator.yml'), 'utf8'
+);
 const criticMd = fs.readFileSync(
   path.join(ROOT, 'references', 'pipeline', 'critic.md'), 'utf8'
 );
@@ -80,4 +89,33 @@ describe('critic label validation', () => {
       'gha-pipeline.md critic tools row must include edit'
     );
   });
+});
+
+describe('pipeline gates allow claude[bot]-authored decomposed children', () => {
+  const gates: Array<[string, string]> = [
+    ['planner.yml', plannerYml],
+    ['critic.yml', criticYml],
+    ['implementer.yml', implementerYml],
+    ['verifier.yml', verifierYml],
+    ['evaluator.yml', evaluatorYml],
+  ];
+
+  for (const [name, yml] of gates) {
+    it(`${name} top-level if allows claude[bot] as issue author`, () => {
+      const ifBlock = yml.match(/if: \|([\s\S]*?)runs-on:/);
+      assert.ok(ifBlock, `${name} must have a top-level if block`);
+      assert.ok(
+        ifBlock![1].includes("'claude[bot]'"),
+        `${name} gate must allowlist 'claude[bot]' so pipeline-authored decomposed children are not stranded`
+      );
+    });
+
+    it(`${name} still restricts sender to repository owner`, () => {
+      const ifBlock = yml.match(/if: \|([\s\S]*?)runs-on:/);
+      assert.ok(
+        ifBlock![1].includes('github.event.sender.login == github.repository_owner'),
+        `${name} must keep sender == owner so only the owner can promote claude[bot] issues into the pipeline`
+      );
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- planner/critic/implementer/verifier/evaluator job `if` gates required `issue.user.login == repository_owner`, which rejected `claude[bot]`-authored decomposed children, stranding #255 (three skipped planner runs on 2026-04-14).
- Allowlist `'claude[bot]'` alongside the owner; keep `sender == repository_owner` so only the owner can promote a claude[bot] issue into the pipeline.
- Adds structural tests in `web/test/pipeline-label-routing.test.ts` covering all 5 stages (both the allowlist and the sender restriction).

Closes #260.

## Test plan

- [x] `npx tsx --test web/test/pipeline-label-routing.test.ts`: 17/17 pass (red before the fix, green after).
- [ ] After merge, re-apply `needs-plan` to #255 and confirm the planner posts "Planner starting." within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)