### PR TITLE
fix: normalize skill polygon against top rank gate (#281)

### DIFF
--- a/web/lib/progression.ts
+++ b/web/lib/progression.ts
@@ -293,13 +293,31 @@ function availableModifiers(polygon: Polygon, config: ProgressionConfig, profile
   );
 }
 
+function getDisplayCeiling(config: ProgressionConfig): number {
+  let ceiling = 1;
+  for (const rank of config.ranks) {
+    const gate = rank.gate;
+    if (!gate) continue;
+    if (gate.all_axes_min !== undefined) {
+      ceiling = Math.max(ceiling, gate.all_axes_min);
+    }
+    if (gate.axes_min) {
+      for (const v of Object.values(gate.axes_min)) ceiling = Math.max(ceiling, v);
+    }
+    if (gate.count_axes_above?.min !== undefined) {
+      ceiling = Math.max(ceiling, gate.count_axes_above.min);
+    }
+  }
+  return ceiling;
+}
+
 function normalizePolygon(polygon: Polygon, config: ProgressionConfig, maxScale = 10): Polygon {
   const axes = axisNames(config);
-  const values = axes.map(a => polygon[a] ?? 0);
-  const max = Math.max(...values, 1);
+  const ceiling = getDisplayCeiling(config);
   const result: Polygon = {};
   for (const axis of axes) {
-    result[axis] = ((polygon[axis] ?? 0) / max) * maxScale;
+    const scaled = ((polygon[axis] ?? 0) / ceiling) * maxScale;
+    result[axis] = Math.min(scaled, maxScale);
   }
   return result;
 }
@@ -359,6 +377,7 @@ export {
   scoreSim,
   availableModifiers,
   normalizePolygon,
+  getDisplayCeiling,
   initPolygon,
   applyDiminishingReturns,
 };

--- a/web/test/progress.test.ts
+++ b/web/test/progress.test.ts
@@ -84,8 +84,8 @@ describe('currentRank (via progress.js wrapper)', () => {
 });
 
 describe('normalizeHexagon (via progress.js wrapper)', () => {
-  it('normalizes to 0-10 scale by default', () => {
-    const poly = { gather: 10, diagnose: 5, correlate: 0, impact: 0, trace: 0, fix: 0 };
+  it('normalizes to 0-10 scale against top rank threshold', () => {
+    const poly = { gather: 6, diagnose: 3, correlate: 0, impact: 0, trace: 0, fix: 0 };
     const norm = normalizeHexagon(poly);
     assert.equal(norm.gather, 10);
     assert.equal(norm.diagnose, 5);
@@ -100,7 +100,7 @@ describe('normalizeHexagon (via progress.js wrapper)', () => {
   });
 
   it('normalizes to custom scale', () => {
-    const poly = { gather: 4, diagnose: 2, correlate: 0, impact: 0, trace: 0, fix: 0 };
+    const poly = { gather: 6, diagnose: 3, correlate: 0, impact: 0, trace: 0, fix: 0 };
     const norm = normalizeHexagon(poly, 5);
     assert.equal(norm.gather, 5);
     assert.equal(norm.diagnose, 2.5);

--- a/web/test/progression.test.ts
+++ b/web/test/progression.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
-import { loadConfig, axisNames, evaluateGate, currentRank, maxDifficulty, applyDecay, scoreSim, availableModifiers, normalizePolygon, initPolygon, applyDiminishingReturns, evaluateQualityGate } from '../lib/progression';
+import { loadConfig, axisNames, evaluateGate, currentRank, maxDifficulty, applyDecay, scoreSim, availableModifiers, normalizePolygon, getDisplayCeiling, initPolygon, applyDiminishingReturns, evaluateQualityGate } from '../lib/progression';
 
 
 const CONFIG_PATH = path.join(__dirname, '..', '..', 'references', 'config', 'progression.yaml');
@@ -438,8 +438,8 @@ describe('availableModifiers', () => {
 describe('normalizePolygon', () => {
   const config = loadConfig(CONFIG_PATH);
 
-  it('normalizes to 0-10 scale', () => {
-    const poly = { gather: 10, diagnose: 5, correlate: 0, impact: 0, trace: 0, fix: 0 };
+  it('normalizes to 0-10 scale against top rank threshold', () => {
+    const poly = { gather: 6, diagnose: 3, correlate: 0, impact: 0, trace: 0, fix: 0 };
     const norm = normalizePolygon(poly, config);
     assert.equal(norm.gather, 10);
     assert.equal(norm.diagnose, 5);
@@ -450,6 +450,24 @@ describe('normalizePolygon', () => {
     for (const axis of axisNames(config)) {
       assert.equal(norm[axis], 0);
     }
+  });
+
+  it('normalizes against the top rank threshold, not player-max', () => {
+    const poly = { gather: 1, diagnose: 0, correlate: 0, impact: 0, trace: 0, fix: 0 };
+    const norm = normalizePolygon(poly, config);
+    assert.equal(Math.round(norm.gather * 100) / 100, 1.67);
+    assert.equal(norm.diagnose, 0);
+  });
+
+  it('clamps axes above the ceiling to maxScale', () => {
+    const poly = { gather: 9, diagnose: 6, correlate: 0, impact: 0, trace: 0, fix: 0 };
+    const norm = normalizePolygon(poly, config);
+    assert.equal(norm.gather, 10);
+    assert.equal(norm.diagnose, 10);
+  });
+
+  it('getDisplayCeiling derives 6 from chaos-architect gate', () => {
+    assert.equal(getDisplayCeiling(config), 6);
   });
 });
 


### PR DESCRIPTION
Closes #281.

## Summary
- `normalizePolygon` no longer divides by the player's own current max, so the strongest axis no longer plots at the outer edge by construction. After one sim the hexagon now shows a small polygon near the center.
- Ceiling is derived from `config.ranks` via `getDisplayCeiling` (scans `all_axes_min`, `axes_min.*`, `count_axes_above.min`). Current yaml yields 6 (chaos-architect). No new config field, so the display scale cannot drift from the top rank gate.
- Output clamps via `Math.min(..., maxScale)` so post-top-rank values pin to the outer edge instead of plotting outside it.

## Test plan
- [x] New tests assert normalization-vs-ceiling, clamp-above-ceiling, and `getDisplayCeiling === 6`
- [x] Updated existing `progression.test.ts` and `progress.test.ts` cases to use ceiling-anchored fixtures
- [x] `npx tsx scripts/test.ts run --files "web/test/progress*.test.ts"` -> 106/106 pass
- [x] Full `npm test` gate: typecheck green; one pre-existing `session-persistence.test.ts` failure unrelated to this change (leftover `learning/sessions/001-ec2-unreachable/` leak detector, tracked separately in the #280 cleanup step)
- [x] Separate-agent verification confirmed all required items

## Rollback
Two commits, each independently `git revert`-able. Reverting the `fix:` commit restores `Math.max(...values, 1)` and the new tests go red.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>