### PR TITLE
fix: snapshot-match leak detection in session-persistence after() hook

### DIFF
--- a/web/test/assert-no-root-leak.test.ts
+++ b/web/test/assert-no-root-leak.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs';
+import { assertNoRootLeak } from './helpers/assert-no-root-leak';
+
+const TMP = path.join(__dirname, '.tmp', `assert-no-root-leak-${process.pid}`);
+fs.mkdirSync(TMP, { recursive: true });
+
+after(() => {
+  try { fs.rmSync(TMP, { recursive: true, force: true }); } catch {}
+});
+
+describe('assertNoRootLeak', () => {
+  it('is silent when path did not pre-exist and does not exist now', () => {
+    const p = path.join(TMP, 'absent-absent');
+    assert.doesNotThrow(() => assertNoRootLeak(p, false));
+  });
+
+  it('is silent when path pre-existed and still exists', () => {
+    const p = path.join(TMP, 'present-present');
+    fs.mkdirSync(p, { recursive: true });
+    assert.doesNotThrow(() => assertNoRootLeak(p, true));
+  });
+
+  it('throws when path did not pre-exist but exists now (leak)', () => {
+    const p = path.join(TMP, 'absent-present');
+    fs.mkdirSync(p, { recursive: true });
+    assert.throws(
+      () => assertNoRootLeak(p, false),
+      /leaked/
+    );
+  });
+
+  it('throws when path pre-existed but no longer exists (removed)', () => {
+    const p = path.join(TMP, 'present-absent');
+    assert.throws(
+      () => assertNoRootLeak(p, true),
+      /removed/
+    );
+  });
+});

--- a/web/test/helpers/assert-no-root-leak.ts
+++ b/web/test/helpers/assert-no-root-leak.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+export function assertNoRootLeak(leakPath: string, preExisted: boolean): void {
+  const existsNow = fs.existsSync(leakPath);
+  if (existsNow === preExisted) return;
+  const verb = existsNow ? 'leaked' : 'was removed';
+  throw new Error(
+    `${leakPath} ${verb} during a test run; tests must use AWS_SIMULATOR_SESSIONS_DIR override`
+  );
+}

--- a/web/test/session-persistence.test.ts
+++ b/web/test/session-persistence.test.ts
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach, after } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
 import fs from 'fs';
+import { assertNoRootLeak } from './helpers/assert-no-root-leak';
 
 const ROOT = path.resolve(__dirname, '..', '..');
 
@@ -11,6 +12,9 @@ const TMP_SESSIONS_DIR = path.join(__dirname, '.tmp', `session-persistence-${pro
 process.env.AWS_SIMULATOR_SESSIONS_DIR = TMP_SESSIONS_DIR;
 fs.mkdirSync(TMP_SESSIONS_DIR, { recursive: true });
 
+const realLeakPath = path.join(ROOT, 'learning', 'sessions', '001-ec2-unreachable');
+const realLeakPreExisted = fs.existsSync(realLeakPath);
+
 // require() preserved for paths and claude-session: must run after
 // AWS_SIMULATOR_SESSIONS_DIR is set above. ESM imports are hoisted before
 // module-level code, which would cause paths.ts to load without the env var.
@@ -19,11 +23,7 @@ const { persistSession, recoverSessions, sessions, SESSION_MAX_AGE_MS } = requir
 
 after(() => {
   try { fs.rmSync(TMP_SESSIONS_DIR, { recursive: true, force: true }); } catch {}
-  const realLeakPath = path.join(ROOT, 'learning', 'sessions', '001-ec2-unreachable');
-  assert.ok(
-    !fs.existsSync(realLeakPath),
-    `learning/sessions/001-ec2-unreachable/ leaked from a test run; tests must use AWS_SIMULATOR_SESSIONS_DIR override`
-  );
+  assertNoRootLeak(realLeakPath, realLeakPreExisted);
 });
 
 describe('persistSession', () => {


### PR DESCRIPTION
## Summary
- Fixes #294 false positive in `web/test/session-persistence.test.ts` after() hook on machines where the real `001-ec2-unreachable` play dir already exists.
- Extracts `assertNoRootLeak(path, preExisted)` helper; after() now asserts final existence matches module-load snapshot, so a newly-appearing dir still trips the leak check.

## Test plan
- [x] `npm run test:file web/test/assert-no-root-leak.test.ts` (4/4 pass, all four snapshot-match cases)
- [x] `npm run test:file web/test/session-persistence.test.ts` (8/8 pass with `learning/sessions/001-ec2-unreachable/` present on disk)
- [x] `npm run typecheck` clean
- [x] `npx tsx scripts/test.ts run --changed` (203/203 pass)
- [x] Verification by separate subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)