### PR TITLE
fix(ci): restore git hooks after base-checkout worktree clobbers them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
           # Compare: fail if any bucket regressed
           npx tsx scripts/health-regression-check.ts /tmp/pr-health.jsonl /tmp/base-health.jsonl
 
+      - name: restore git hooks from PR checkout (Issue #343)
+        # The health-regression step above runs `npm ci` inside a worktree at
+        # BASE_SHA. Its postinstall re-runs install-git-hooks.ts which writes
+        # into the SHARED `.git/hooks/` dir (resolved via --git-common-dir),
+        # overwriting the PR's post-commit with the base version. Re-install
+        # from the PR checkout so the doctor check below sees the PR version.
+        run: npm run install-git-hooks
+
       - name: seed per-user state for doctor
         run: |
           # learning/system-vault/ is gitignored (per-user state). The doctor


### PR DESCRIPTION
Closes #343

## Summary
- CI `doctor` step fails on any PR that edits `.claude/hooks/post-commit` (first hit: PR #336) because the health-regression step's `npm ci` inside a BASE_SHA worktree overwrites the SHARED `.git/hooks/post-commit` with the old version.
- Re-running `npm run install-git-hooks` in the main checkout, right after the regression step, restores the hook the doctor check expects.

## Test plan
- [ ] CI on this PR runs `install-git-hooks` twice (postinstall + new step) and `npm run doctor` passes.
- [ ] After merge, rebase PR #336 on master and confirm its CI turns green.