### PR TITLE
fix(evaluator): clarify steps: is required playbook frontmatter key

### DIFF
--- a/references/pipeline/evaluator.md
+++ b/references/pipeline/evaluator.md
@@ -127,10 +127,11 @@ updated: {{TODAY}}
 source_issues: [#{{ISSUE}}]
 confidence: observed | inferred | ambiguous
 summary: <one sentence, <= 160 chars>
-# PROBLEM adds: triggers, solutions, related_problems, severity
-# SOLUTION adds: applies_to, preconditions, cost
-# PLAYBOOK adds: when, steps, related
-# PATTERN adds:  principle, counter_examples
+# Kind-specific frontmatter keys (all listed keys are REQUIRED as frontmatter, not body sections):
+# PROBLEM:  triggers, solutions, related_problems, severity
+# SOLUTION: applies_to, preconditions, cost
+# PLAYBOOK: when, steps, related   <- steps: must be a frontmatter key (count or inline list); the `## Steps` body section does NOT satisfy it
+# PATTERN:  principle, counter_examples
 ---
 ```
 


### PR DESCRIPTION
Closes #362

## Summary
Evaluator prompt schema comment `# PLAYBOOK adds: when, steps, related` was easily misread: the LLM can treat `steps` as a body-section hint (there is a conventional `## Steps` markdown block in playbooks) and omit the frontmatter key.

PR #355 hit this: generated playbook had `## Steps` body but no `steps:` frontmatter, vault-lint blocked the merge. Temporary inline fix at 24b035f.

## Change
One-block edit to `references/pipeline/evaluator.md` (5 +/4 -). Kind-specific field list now explicitly says the keys are REQUIRED frontmatter (not body sections), with inline note that `## Steps` does not satisfy `steps:`.

## Test plan
- [x] `npm test` passes (1023/1023 unit, vault-lint ok)